### PR TITLE
Fix static build when CONTAINERD_VERS=0

### DIFF
--- a/dockerd-starting.sh
+++ b/dockerd-starting.sh
@@ -26,9 +26,8 @@ else
     ps -aef | grep docker | grep -v grep
     sleep 10
     ps -aef
-    if ! test -d /root/.docker
+    if [[ ! -z ${DOCKER_SECRET_AUTH+z} ]] && [ ! -d /root/.docker ]
     then
-        # Docker login : only for tests
         mkdir /root/.docker
         echo "$DOCKER_SECRET_AUTH" > /root/.docker/config.json
         echo "Docker login" 2>&1 | tee -a ${LOG}

--- a/get_env.sh
+++ b/get_env.sh
@@ -54,9 +54,9 @@ echo RPMS=\"`cd docker-ce-packaging/rpm && ls -1d centos-* fedora-*`\" >> ${FILE
 source /workspace/${FILE_ENV_DISTRIB}
 
 # Get the containerd directory if we don't want to build containerd
-if [[ ${CONTAINERD_VERS} = "0" ]]
+if [[ ${CONTAINERD_BUILD} = "0" ]]
 then
-    cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/containerd-* /workspace/
+    cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/containerd-${CONTAINERD_VERS} /workspace/
 fi
 
 # Check if we have the env.list, the env-distrib.list and the dockertest
@@ -66,11 +66,11 @@ then
     exit 1
 else
 # check there are 3 env variables in env.list
-    if grep -Fq "DOCKER_VERS" ${FILE_ENV} && grep -Fq "CONTAINERD_VERS" ${FILE_ENV} && grep -Fq "PACKAGING_REF" ${FILE_ENV}
+    if grep -Fq "DOCKER_VERS" ${FILE_ENV} && grep -Fq "CONTAINERD_BUILD" ${FILE_ENV} && grep -Fq "CONTAINERD_VERS" ${FILE_ENV} && grep -Fq "PACKAGING_REF" ${FILE_ENV}
     then
-        echo "DOCKER_VERS, CONTAINERD_VERS, PACKAGING_REF are in env.list" 2>&1 | tee -a ${LOG}
+        echo "DOCKER_VERS, CONTAINERD_BUILD, CONTAINERD_VERS, PACKAGING_REF are in env.list" 2>&1 | tee -a ${LOG}
     else
-        echo "DOCKER_VERS, CONTAINERD_VERS and/or PACKAGING_REF are not in env.list" 2>&1 | tee -a ${LOG}
+        echo "DOCKER_VERS, CONTAINERD_BUILC, CONTAINERD_VERS and/or PACKAGING_REF are not in env.list" 2>&1 | tee -a ${LOG}
         exit 1
     fi
 # check there are two env variables in env-distrib.list
@@ -83,9 +83,9 @@ else
     fi
 fi
 
-if [[ ${CONTAINERD_VERS} = "0" ]]
+if [[ ${CONTAINERD_BUILD} = "0" ]]
 then
-    if test -d /workspace/containerd-*
+    if test -d /workspace/containerd-${CONTAINERD_VERS}
     then
         echo "The containerd packages have been copied." 2>&1 | tee -a ${LOG}
     else

--- a/test-staging-DEBS/Dockerfile
+++ b/test-staging-DEBS/Dockerfile
@@ -1,0 +1,79 @@
+# Dockerfile to run the staging tests
+
+ARG GOLANG_VERSION=1.15.2
+ARG DISTRO_NAME
+ARG DISTRO_VERS
+
+FROM ppc64le/$DISTRO_NAME:$DISTRO_VERS
+
+ARG GOLANG_VERSION
+ARG DISTRO_NAME
+ARG DISTRO_VERS
+
+WORKDIR /workspace
+RUN mkdir -p /workspace
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+ENV PATH /usr/local/go/bin:$PATH
+
+
+RUN if [ -f /bin/rpm  ] ; \
+    then\
+     echo rpm ; \
+     set -eux; yum -y install wget make gcc findutils;\
+    else \
+        echo deb;\
+        apt-get update && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        wget \
+        software-properties-common \
+        lsb-release\
+        make\
+        gcc\
+        libc-dev\
+        procps\
+        iptables libdevmapper1.02.1 && \
+        rm -rf /var/lib/apt/lists/* ;\
+    fi
+
+#Install from Docker-ce staging
+RUN set -eux; curl -fsSL https://download-stage.docker.com/linux/${DISTRO_NAME}/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
+    echo "deb [arch=ppc64el signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download-stage.docker.com/linux/${DISTRO_NAME} ${DISTRO_VERS} stable"\
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null  &&\
+    apt-get update && apt-get -y install docker-ce docker-ce-cli containerd.io
+
+##
+#Docker in Docker inspired from
+#  https://github.com/docker-library/docker/tree/master/20.10/dind
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+##
+RUN set -eux; \
+        addgroup --system dockremap; \
+        adduser --system --ingroup dockremap dockremap; \
+        echo 'dockremap:165536:65536' >> /etc/subuid; \
+        echo 'dockremap:165536:65536' >> /etc/subgid
+
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT ed89041433a031cafc0a0f19cfe573c31688d377
+
+RUN set -eux; \
+        wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
+        chmod +x /usr/local/bin/dind;
+
+RUN set -eux; \
+	url="https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-ppc64le.tar.gz";\
+    wget -O go.tgz "$url" --progress=dot:giga; \
+    tar -C /usr/local -xzf go.tgz; \
+    rm go.tgz; \
+    go version;
+
+COPY test_launch.sh /usr/local/bin
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+
+ENTRYPOINT ["test_launch.sh"]
+CMD []

--- a/test-staging-RPMS/Dockerfile
+++ b/test-staging-RPMS/Dockerfile
@@ -1,0 +1,56 @@
+# Dockerfile to run the staging tests
+
+ARG GOLANG_VERSION=1.15.2
+ARG DISTRO_NAME
+ARG DISTRO_VERS
+
+FROM ppc64le/$DISTRO_NAME:$DISTRO_VERS
+
+ARG GOLANG_VERSION
+ARG DISTRO_NAME
+ARG DISTRO_VERS
+
+WORKDIR /workspace
+RUN mkdir -p /workspace
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+ENV PATH /usr/local/go/bin:$PATH
+
+RUN set -eux; yum -y install wget make gcc findutils procps-ng
+
+RUN set -eux; yum install -y yum-utils &&\
+	yum-config-manager --add-repo https://download-stage.docker.com/linux/${DISTRO_NAME}/docker-ce-staging.repo &&\
+	yum -y install docker-ce docker-ce-cli containerd.io
+
+##
+#Docker in Docker inspired from
+#  https://github.com/docker-library/docker/tree/master/20.10/dind
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+##
+RUN set -eux; \
+	groupadd --system dockremap; \
+	adduser --system -g dockremap dockremap; \
+	echo 'dockremap:165536:65536' >> /etc/subuid; \
+	echo 'dockremap:165536:65536' >> /etc/subgid
+
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT ed89041433a031cafc0a0f19cfe573c31688d377
+
+RUN set -eux; \
+	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
+	chmod +x /usr/local/bin/dind;
+
+RUN set -eux; \
+	url="https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-ppc64le.tar.gz";\
+    wget -O go.tgz "$url" --progress=dot:giga; \
+    tar -C /usr/local -xzf go.tgz; \
+    rm go.tgz; \
+    go version;
+
+COPY test_launch.sh /usr/local/bin
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+
+ENTRYPOINT ["test_launch.sh"]
+CMD []

--- a/test.sh
+++ b/test.sh
@@ -112,6 +112,8 @@ do
         echo "Tests done" 2>&1 | tee -a ${LOG}
       fi
 
+      # Copy the logs to the COS bucket
+
       # Stop and remove the docker container
       echo "### ### # Cleanup: ${CONT_NAME} # ### ###"
       docker stop ${CONT_NAME}
@@ -171,6 +173,8 @@ do
         echo "Tests done" 2>&1 | tee -a ${LOG}
       fi
 
+      # Copy the logs to the COS bucket
+
       # Stop and remove the docker container
       echo "### ### # Cleanup: ${CONT_NAME_STATIC} # ### ###" 2>&1 | tee -a ${LOG}
       docker stop ${CONT_NAME_STATIC}
@@ -215,6 +219,8 @@ do
       [[ "$TEST" -eq "0" ]] && [[ "$TEST_STATIC" -eq "0" ]]
       echo "All : $?" 2>&1 | tee -a ${PATH_TEST_ERRORS}
       tail -9 ${PATH_TEST_ERRORS} 2>&1 | tee -a ${LOG}
+
+      # Copy the errors.txt to the COS bucket
     else
       echo "There is no ${TEST_LOG} or ${TEST_LOG_STATIC} file." 2>&1 | tee -a ${LOG}
     fi

--- a/test_staging.sh
+++ b/test_staging.sh
@@ -1,0 +1,129 @@
+#/bin/bash
+
+##
+# docker run -d -v /home/fpascual:/workspace -v /home/fpascual/.docker/config.json:/root/.docker/config.json --privileged --name docker-test-staging quay.io/powercloud/docker-ce-build
+# docker exec -it docker-test-staging /bin/bash
+##
+#set -eux
+
+set -ue
+
+set -o allexport
+source env.list
+source env-distrib.list
+
+DIR_TEST="/workspace/test-staging_docker-ce-${DOCKER_VERS}_containerd-${CONTAINERD_VERS}"
+PATH_DOCKERFILE="${PATH_SCRIPTS}/test-staging"
+PATH_TEST_ERRORS="${DIR_TEST}/errors.txt"
+
+# Create the test directory
+if ! test -d ${DIR_TEST}
+then
+    mkdir -p "${DIR_TEST}"
+fi
+
+# Create the errors.txt file where we will put a summary of the test logs
+if ! test -f ${PATH_TEST_ERRORS}
+then
+    touch ${PATH_TEST_ERRORS}
+else
+    rm ${PATH_TEST_ERRORS}
+    touch ${PATH_TEST_ERRORS}
+fi
+
+for PACKTYPE in DEBS RPMS
+do
+    echo "# Looking for distro type: ${PACKTYPE} #" 2>&1 | tee -a ${LOG}
+
+    for DISTRO in ${!PACKTYPE}
+    do
+        echo "## Looking for ${DISTRO} ##" 2>&1 | tee -a ${LOG}
+        DISTRO_NAME="$(cut -d'-' -f1 <<<"${DISTRO}")"
+        DISTRO_VERS="$(cut -d'-' -f2 <<<"${DISTRO}")"
+
+	# Get all environment variables
+        IMAGE_NAME="t_docker_${DISTRO_NAME}_${DISTRO_VERS}"
+        CONT_NAME="t_docker_run_${DISTRO_NAME}_${DISTRO_VERS}"
+        BUILD_LOG="build_${DISTRO_NAME}_${DISTRO_VERS}.log"
+        TEST_LOG="test_${DISTRO_NAME}_${DISTRO_VERS}.log"
+
+        export DISTRO_NAME
+
+        echo "### Tests for docker-ce and containerd packages ###" 2>&1 | tee -a ${LOG}
+        # Get in the tmp directory and get the Dockerfile
+        if ! test -d tmp
+        then
+            mkdir tmp
+        else
+            rm -rf tmp
+            mkdir tmp
+        fi
+
+        pushd tmp
+        echo "### # Copying the packages and the dockerfile for ${DISTRO} # ###" 2>&1 | tee -a ${LOG}
+        # Copy the Dockerfile
+        cp ${PATH_DOCKERFILE}-${PACKTYPE}/Dockerfile .
+        # Copy the test_launch.sh which will be copied in /usr/local/bin
+        cp ${PATH_SCRIPTS}/test_launch.sh .
+
+	# Check if we have the Dockerfile and the test_launch.sh
+	ls Dockerfile && ls test_launch.sh
+	if [[ $? -ne 0 ]]
+	then
+	    # The Dockerfile and/or the test_launch.sh is/are missing
+	    echo "The Dockerfile and/or the test_launch.sh is/are missing." 2>&1 | tee -a ${LOG}
+	    continue
+	else
+	    # Building the test image
+            echo "### ## Building the test image: ${IMAGE_NAME} ## ###" 2>&1 | tee -a ${LOG}
+            docker build -t ${IMAGE_NAME} --build-arg DISTRO_NAME=${DISTRO_NAME} --build-arg DISTRO_VERS=${DISTRO_VERS} . 2>&1 | tee ${DIR_TEST}/${BUILD_LOG}
+
+            if [[ $? -ne 0 ]]; then
+                echo "ERROR: docker build failed for ${DISTRO}, see details from '${BUILD_LOG}'" 2>&1 | tee -a ${LOG}
+                continue
+            else
+                echo "Docker build for ${DISTRO} done" 2>&1 | tee -a ${LOG}
+            fi
+
+            echo "### ### Running the tests from the container: ${CONT_NAME} ### ###" 2>&1 | tee -a ${LOG}
+            docker run --env DOCKER_SECRET_AUTH --env DISTRO_NAME --env PATH_SCRIPTS --env LOG -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} --privileged --name $CONT_NAME ${IMAGE_NAME}
+
+	    status_code="$(docker container wait $CONT_NAME)"
+            if [[ ${status_code} -ne 0 ]]; then
+                echo "ERROR: The test suite failed for ${DISTRO}. See details from '${TEST_LOG}'" 2>&1 | tee -a ${LOG}
+                docker logs $CONT_NAME 2>&1 | tee ${DIR_TEST}/${TEST_LOG}
+            else
+                docker logs $CONT_NAME 2>&1 | tee ${DIR_TEST}/${TEST_LOG}
+                echo "Tests done" 2>&1 | tee -a ${LOG}
+            fi
+
+            echo "### ### # Cleanup: ${CONT_NAME} # ### ###"
+            docker stop ${CONT_NAME}
+            docker rm ${CONT_NAME}
+            docker image rm ${IMAGE_NAME}
+	fi
+	popd
+        rm -rf tmp
+
+	# Check the logs and get in the errors.txt a summary of the error logs
+        if test -f ${DIR_TEST}/${TEST_LOG}
+        then
+            echo "### # Checking the logs # ###"
+            echo "DISTRO ${DISTRO_NAME} ${DISTRO_VERS}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+            TEST_1=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
+            echo "TestDistro : ${TEST_1}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+
+            TEST_2=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
+            echo "TestDistroInstallPackage : ${TEST_2}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+
+            TEST_3=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==4' | rev | cut -d' ' -f 1")
+            echo "TestDistroPackageCheck : ${TEST_3}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+
+            [[ "$TEST_1" -eq "0" ]] && [[ "$TEST_2" -eq "0" ]] && [[ "$TEST_3" -eq "0" ]]
+            echo "All : $?" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+            tail -5 ${PATH_TEST_ERRORS}
+        else
+            echo "There is no ${TEST_LOG} file." 2>&1 | tee -a ${LOG}
+        fi
+    done
+done


### PR DESCRIPTION
The static build command now needs the version number of containerd specified and in the case where there is no new containerd version, CONTAINERD_VERS was supposed to be equal to 0 to avoid building it.
Fix : CONTAINERD_VERS will always take the version number of containerd whether we build the dynamic packages or not and CONTAINERD_BUILD will be equal to 0 if we don't want to build the dynamic packages (and we check in that case, if we already built containerd for all distributions, identified for docker-ce-packaging)