### PR TITLE
Fix git clone containerd + added date + added push of the log + fix w…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -241,7 +241,13 @@ else
       # Build the package
       if ! test -d containerd-packaging
       then
-        git clone https://github.com/docker/containerd-packaging.git
+          mkdir containerd-packaging
+          pushd containerd-packaging
+          git init
+          git remote add origin https://github.com/docker/containerd-packaging.git
+          git fetch --depth 1 origin ${CONTAINERD_PACKAGING_REF}
+          git checkout FETCH_HEAD
+          make REF=${CONTAINERD_VERS} checkout
       fi
       pushd containerd-packaging
 

--- a/check_tests.sh
+++ b/check_tests.sh
@@ -7,7 +7,7 @@ set -o allexport
 source env.list
 source env-distrib.list
 
-DIR_TEST="/workspace/test_docker-ce-${DOCKER_VERS}_containerd-${CONTAINERD_VERS}"
+DIR_TEST="/workspace/test_docker-ce-${DOCKER_VERS}_containerd-${CONTAINERD_VERS}_${DATE}"
 PATH_TEST_ERRORS="${DIR_TEST}/errors.txt"
 
 # Check if there is a errors.txt file

--- a/prowjob-periodic-dind-build.sh
+++ b/prowjob-periodic-dind-build.sh
@@ -2,18 +2,16 @@
 
 set -ue
 
-
 # Paths to the scripts and to the log
 PATH_SCRIPTS="/home/prow/go/src/github.com/ppc64le-cloud/docker-ce-build"
+DATE=`date +%d%m%y-%H%S`
 
 if [[ ! -z ${ARTIFACTS} ]]
 then
-    LOG="${ARTIFACTS}/prowjob.log"
+    LOG="${ARTIFACTS}/prowjob_${DATE}.log"
 else
-    LOG="/workspace/prowjob.log"
+    LOG="/workspace/prowjob_${DATE}.log"
 fi
-
-DATE=`date +%d%m%y-%H%S`
 
 export DATE
 export PATH_SCRIPTS

--- a/push_COS.sh
+++ b/push_COS.sh
@@ -105,12 +105,24 @@ then
     then
         ls ${PATH_COS}/s3_${COS_BUCKET_SHARED}
         echo "No error in the tests and shared bucket mounted." 2>&1 | tee -a ${LOG}
+        if [[ -z ${ARTIFACTS} ]]
+        then
+            cp ${LOG} ${DIR_COS_BUCKET}
+        fi
         exit 0
     else
         echo "No error in the tests but shared bucket not mounted." 2>&1 | tee -a ${LOG}
+        if [[ -z ${ARTIFACTS} ]]
+        then
+            cp ${LOG} ${DIR_COS_BUCKET}
+        fi
         exit 1
     fi
 else
     echo "There were some errors in the test, the packages have been pushed only to the private COS Bucket." 2>&1 | tee -a ${LOG}
+    if [[ -z ${ARTIFACTS} ]]
+    then
+        cp ${LOG} ${DIR_COS_BUCKET}
+    fi
     exit 1
 fi

--- a/test-static-alpine/Dockerfile
+++ b/test-static-alpine/Dockerfile
@@ -79,5 +79,5 @@ RUN mkdir /certs /certs/client && chmod 1777 /certs /certs/client
 VOLUME /var/lib/docker
 EXPOSE 2375 2376
 
-ENTRYPOINT ["test_launch.sh"]
+ENTRYPOINT ["/usr/local/bin/test_launch.sh"]
 CMD []

--- a/test.sh
+++ b/test.sh
@@ -35,12 +35,12 @@ then
 fi
 
 # Create the errors.txt file where we will put a summary of the test logs
-if ! test -f ${PATH_TEST_ERRORS}
+if ! test -f ${PATH_ERRORS}
 then
-  touch ${PATH_TEST_ERRORS}
+  touch ${PATH_ERRORS}
 else
-  rm ${PATH_TEST_ERRORS}
-  touch ${PATH_TEST_ERRORS}
+  rm ${PATH_ERRORS}
+  touch ${PATH_ERRORS}
 fi
 
 echo "# Tests of the dynamic packages #"
@@ -159,11 +159,11 @@ do
 
     # Check the logs and get in the errors.txt a summary of the error logs
     echo "### ### ## Checking the logs ## ### ###" 2>&1 | tee -a ${LOG}
-    echo "DISTRO ${DISTRO_NAME} ${DISTRO_VERS}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+    echo "DISTRO ${DISTRO_NAME} ${DISTRO_VERS}" 2>&1 | tee -a ${PATH_ERRORS}
 
     if test -f ${DIR_TEST}/${TEST_LOG} && [[ $(eval "cat ${DIR_TEST}/${TEST_LOG} | grep -c exitCode") == 4 ]]
     then
-      echo "Dynamic packages" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+      echo "Dynamic packages" 2>&1 | tee -a ${PATH_ERRORS}
       # We get 4 exitCodes in the log (3 tests + the output of the first containing exitCode)
       TEST_1=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
       TEST_2=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
@@ -174,9 +174,9 @@ do
       TEST_3=1
     fi
 
-    echo "TestDistro : ${TEST_1}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
-    echo "TestDistroInstallPackage : ${TEST_2}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
-    echo "TestDistroPackageCheck : ${TEST_3}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+    echo "TestDistro : ${TEST_1}" 2>&1 | tee -a ${PATH_ERRORS}
+    echo "TestDistroInstallPackage : ${TEST_2}" 2>&1 | tee -a ${PATH_ERRORS}
+    echo "TestDistroPackageCheck : ${TEST_3}" 2>&1 | tee -a ${PATH_ERRORS}
 
     [[ "$TEST_1" -eq "0" ]] && [[ "$TEST_2" -eq "0" ]] && [[ "$TEST_3" -eq "0" ]]
     TEST=$?
@@ -251,7 +251,7 @@ else
 
   status_code="$(docker container wait ${CONT_NAME_STATIC})"
   if [[ ${status_code} -ne 0 ]]; then
-    echo "ERROR: The test suite failed for ${DISTRO}. See details from '${TEST_LOG_STATIC}'" 2>&1 | tee -a ${LOG}
+    echo "ERROR: The test suite failed for ${DISTRO_NAME}. See details from '${TEST_LOG_STATIC}'" 2>&1 | tee -a ${LOG}
     docker logs ${CONT_NAME_STATIC} 2>&1 | tee ${DIR_TEST}/${TEST_LOG_STATIC}
   else
     docker logs ${CONT_NAME_STATIC} 2>&1 | tee ${DIR_TEST}/${TEST_LOG_STATIC}
@@ -280,7 +280,7 @@ rm -rf tmp
 
 if test -f ${DIR_TEST}/${TEST_LOG_STATIC} && [[ $(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep -c exitCode") == 4 ]]
 then
-  echo "Static binaries" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+  echo "Static binaries" 2>&1 | tee -a ${PATH_ERRORS}
   # We get 4 exitCodes in the log (3 tests + the output of the first containing exitCode)
   TEST_1_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
   TEST_2_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
@@ -291,16 +291,16 @@ else
   TEST_3_STATIC=1
 fi
 
-echo "TestDistro : ${TEST_1_STATIC}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
-echo "TestDistroInstallPackage : ${TEST_2_STATIC}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
-echo "TestDistroPackageCheck : ${TEST_3_STATIC}" 2>&1 | tee -a ${PATH_TEST_ERRORS}
+echo "TestDistro : ${TEST_1_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
+echo "TestDistroInstallPackage : ${TEST_2_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
+echo "TestDistroPackageCheck : ${TEST_3_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
 
 [[ "$TEST_1_STATIC" -eq "0" ]] && [[ "$TEST_2_STATIC" -eq "0" ]] && [[ "$TEST_3_STATIC" -eq "0" ]]
 TEST_STATIC=$?
 
 [[ "$TEST" -eq "0" ]] && [[ "$TEST_STATIC" -eq "0" ]]
-echo "All : $?" 2>&1 | tee -a ${PATH_TEST_ERRORS}
-tail -9 ${PATH_TEST_ERRORS} 2>&1 | tee -a ${LOG}
+echo "All : $?" 2>&1 | tee -a ${PATH_ERRORS}
+tail -9 ${PATH_ERRORS} 2>&1 | tee -a ${LOG}
 
 # Copying the errors.txt to the COS bucket
 cp ${PATH_ERRORS} ${PATH_ERRORS_COS}


### PR DESCRIPTION
- Changed git clone containerd, when CONTAINERD_BUILD is set to 0 (which means, that there is no new containerd version, but there are new distributions)
- Added date to the prow job log to ensure it does not get overwritten
- Added a push of the log at the end of the prow job, in case the cos bucket is not connected to the prow job (and in case the prow job does not push automatically the log to the cos bucket
- Fixed when the container is waiting for dockerd to start (when the pid of dockerd is found, it does not mean that the dockerd is ready and can display docker info)