### PR TITLE
Add new settings DISABLE_DISTRO_DISCOVERY, DISABLE_PUSH_COS

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -120,7 +120,7 @@ do
 
     if [[ $n -eq "1" ]]
     then
-      echo "Ready to launch up to 4 builds in parralel"
+      echo "Ready to launch up to 4 builds in parallel"
       pids=()
     fi
 
@@ -131,11 +131,11 @@ do
 
     if [[ $i -eq $nb ]] || [[ $n -eq "0" ]]
     then
-      #TODO Imrpove this: we could wait for the 1st build to complete instead of
+      #TODO Improve this: we could wait for the 1st build to complete instead of
       # waiting for all the 4 build see  'wait -n'. Or else rely on 'make -j'
       echo "Waiting for the '${#pids[@]}' builds to complete"
       wait ${pids[@]}
-      echo "Wait comleted"
+      echo "Wait completed"
     fi
 
     let "i=i+1"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -114,12 +114,13 @@ for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}
   do
-    echo "i : $i"
+    echo "Distro build count: $i"
+
     n=$(($i%4))
-    echo "n = $n"
+
     if [[ $n -eq "1" ]]
     then
-      echo "We initialise the pids"
+      echo "Ready to launch up to 4 builds in parralel"
       pids=()
     fi
 
@@ -130,8 +131,11 @@ do
 
     if [[ $i -eq $nb ]] || [[ $n -eq "0" ]]
     then
-      echo "We wait for the pids"
+      #TODO Imrpove this: we could wait for the 1st build to complete instead of
+      # waiting for all the 4 build see  'wait -n'. Or else rely on 'make -j'
+      echo "Waiting for the '${#pids[@]}' builds to complete"
       wait ${pids[@]}
+      echo "Wait comleted"
     fi
 
     let "i=i+1"

--- a/check-tests.sh
+++ b/check-tests.sh
@@ -11,6 +11,8 @@ source ${FILE_ENV}
 DIR_TEST="/workspace/tests"
 PATH_TEST_ERRORS="${DIR_TEST}/errors.txt"
 
+TEST_MODE="${1:-local}"
+
 # Check if there is a errors.txt file
 if ! test -f ${PATH_TEST_ERRORS}
 then
@@ -27,7 +29,15 @@ NB_TEST_LOGS=$(eval "find ${DIR_TEST}/test* | wc -l")
 echo "Nb of build logs : ${NB_BUILD_LOGS}"
 echo "Nb of test logs : ${NB_TEST_LOGS}"
 
-DISTROS=$(eval "echo $DEBS $RPMS alpine | tr '-' '_'")
+
+DISTROS=$(eval "echo $DEBS $RPMS | tr '-' '_'")
+
+if [[ "$TEST_MODE" = "local" ]]; then
+  DISTROS+=" alpine"
+else
+  echo "Skip test static for TEST_MODE: $TEST_MODE"
+fi
+
 echo "List of distros : ${DISTROS}"
 NB_DISTROS=$(eval "echo ${DISTROS} | wc -w")
 echo "Nb of distros : ${NB_DISTROS}"

--- a/env/env.list
+++ b/env/env.list
@@ -19,3 +19,24 @@ RUNC_VERS="v1.0.3"
 
 #If not empty, specify the GO version for building containerd
 GOLANG_VERSION="1.16.15"
+
+##
+# If '1' disable Linux distribution discovery from get-env.sh
+# RPMS and DEBS must be set adnd contains the list of distro such as "fedora-34"
+###
+DISABLE_DISTRO_DISCOVERY=1
+RPMS="fedora-34"
+DEBS="ubuntu-bionic"
+
+##
+# Shared COS Bucket info (with Docker)
+##
+COS_BUCKET_SHARED="ibm-docker-builds"
+URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
+
+##
+# If '1' disable push to shared COS
+# This is useful when testing or debugging the script
+# and we do not want to publish the packages on the official repo
+###
+DISABLE_PUSH_COS=1

--- a/env/env.list
+++ b/env/env.list
@@ -22,7 +22,7 @@ GOLANG_VERSION="1.16.15"
 
 ##
 # If '1' disable Linux distribution discovery from get-env.sh
-# RPMS and DEBS must be set adnd contains the list of distro such as "fedora-34"
+# RPMS and DEBS must be set and contains the list of distro such as "fedora-34"
 ###
 DISABLE_DISTRO_DISCOVERY=1
 RPMS="fedora-34"

--- a/env/test-release.list
+++ b/env/test-release.list
@@ -1,0 +1,2 @@
+# Update this file to spwan the prow job postsubmit-test-docker-release
+

--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,0 +1,3 @@
+
+# Update this file to spwan the prow job postsubmit-test-docker-staging
+

--- a/prow-build-containerd.sh
+++ b/prow-build-containerd.sh
@@ -63,13 +63,17 @@ ${PATH_SCRIPTS}/dockerctl.sh stop
 if [[ ${CHECK_TESTS_BOOL} -eq 0 ]]
 then
     echo "NO ERROR"
-    # Push to the COS Bucket according to CHECK_TESTS_BOOL
-    echo "*** *** Push to the COS Buckets *** ***"
-    ${PATH_SCRIPTS}/push-COS.sh
-
-    exit $?
-
 else
     echo "ERROR"
     exit 1
+fi
+
+if [[ ${DISABLE_PUSH_COS} = "1" ]]
+then
+    echo "Skip push to COS, DISABLE_PUSH_COS=${DISABLE_PUSH_COS}"
+else
+    # Push to the COS Bucket according to CHECK_TESTS_BOOL
+    echo "*** *** Push to the COS Buckets *** ***"
+    ${PATH_SCRIPTS}/push-COS.sh
+    exit $?
 fi

--- a/prow-test-docker.sh
+++ b/prow-test-docker.sh
@@ -56,7 +56,7 @@ bash -x ${PATH_SCRIPTS}/test.sh ${TEST_MODE}
 
 # Check if there are errors in the tests : NOERR or ERR
 echo "*** ** Tests check ** ***"
-${PATH_SCRIPTS}/check-tests.sh
+${PATH_SCRIPTS}/check-tests.sh ${TEST_MODE}
 CHECK_TESTS_BOOL=`echo $?`
 echo "Exit code check : ${CHECK_TESTS_BOOL}"
 echo "The tests results : ${CHECK_TESTS_BOOL}"

--- a/push-COS.sh
+++ b/push-COS.sh
@@ -9,12 +9,7 @@ source env.list
 
 PATH_COS="/mnt"
 PATH_PASSWORD="/root/.s3fs_cos_secret"
-
-COS_BUCKET_SHARED="ibm-docker-builds"
-URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
-
 PATH_DISTROS_MISSING="/workspace/distros-missing.txt"
-
 
 echo "- Push to ibm-docker-builds -"
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ##
-# Script testing the docker-ce and containerd packages and the static binaries
+# Test the docker-ce and containerd packages and the static binaries
 # Usage: test.sh [local | staging | release]
 ##
 set -u
@@ -29,6 +29,313 @@ checkFile() {
     echo "$1 already created"
   fi
 }
+
+##
+# Test docker + containerd dynamic packages for a given $DISTRO
+# Set: $TEST
+##
+testDynamicPackages() {
+
+  begin=$SECONDS
+  echo "## Looking for ${DISTRO} ##"
+  DISTRO_NAME="$(cut -d'-' -f1 <<<"${DISTRO}")"
+  DISTRO_VERS="$(cut -d'-' -f2 <<<"${DISTRO}")"
+
+  # Get all environment variables
+  IMAGE_NAME="t_docker_${DISTRO_NAME}_${DISTRO_VERS}"
+  CONT_NAME="t_docker_run_${DISTRO_NAME}_${DISTRO_VERS}"
+  BUILD_LOG="build_${DISTRO_NAME}_${DISTRO_VERS}.log"
+  TEST_LOG="test_${DISTRO_NAME}_${DISTRO_VERS}.log"
+  TEST_JUNIT="junit-tests-${DISTRO_NAME}-${DISTRO_VERS}.xml"
+
+  export DISTRO_NAME
+  export DISTRO_VERS
+
+  # Get in the tmp directory and get the docker-ce and containerd packages and the Dockerfile in it
+  checkDirectory tmp
+  pushd tmp
+
+  cp ${PATH_DOCKERFILE}-${PACKTYPE}/Dockerfile .
+  cp ${PATH_SCRIPTS}/test-launch.sh .
+
+  ###
+  # Local test only: copy the packages that we just built
+  ###
+  if [[ "$TEST_MODE" = "local" ]]; then
+
+    echo "### Copying the packages and the dockerfile for ${DISTRO} ###"
+    # Copy the docker-ce packages
+    cp ${DIR_DOCKER}/bundles-ce-${DISTRO_NAME}-${DISTRO_VERS}-ppc64*.tar.gz .
+    # Copy the containerd packages (we have two different configurations depending on the package type)
+    CONTAINERD_VERS_2=$(echo ${CONTAINERD_VERS} | cut -d'v' -f2)
+    if [[ ${PACKTYPE} == "DEBS" ]]
+    then
+      # For the debian packages, we don't want the dbgsym package
+      cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io_${CONTAINERD_VERS_2}*_ppc64*.deb .
+    elif [[ ${PACKTYPE} == "RPMS" ]]
+    then
+      cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io-${CONTAINERD_VERS_2}*.ppc64*.rpm .
+    fi
+
+    # Check if we have the docker-ce and containerd packages and the Dockerfile and the test-launch.sh
+    ls bundles-ce-${DISTRO_NAME}-${DISTRO_VERS}-ppc64le.tar.gz && ls containerd*ppc64*.* && ls Dockerfile && ls test-launch.sh
+    if [[ $? -ne 0 ]]
+    then
+      # The docker-ce packages and/or the containerd packages and/or the Dockerfile is/are missing
+      echo "ERROR: The docker-ce packages and/or the containerd packages and/or the Dockerfile is/are missing"
+      continue
+    fi
+
+  fi
+
+  echo "### # Building the test image: ${IMAGE_NAME} # ###"
+  # Building the test image
+  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8* ]]
+  then
+    ##
+    # Switch to quay.io for CentOS 8 stream
+    # See https://github.com/docker/containerd-packaging/pull/263
+    # See https://github.com/docker-library/official-images/pull/11831
+    ##
+    echo "Temporary fix: patching Dockerfile for using CentOS 8 stream and quay.io "
+    sed -i 's/FROM ppc64le.*/FROM quay.io\/centos\/centos\:stream8/g' Dockerfile
+  fi
+
+  BUILD_ARGS="--build-arg DISTRO_NAME=${DISTRO_NAME} --build-arg DISTRO_VERS=${DISTRO_VERS}"
+
+  if [[ "$TEST_MODE" = "staging" || "$TEST_MODE" = "release"  ]]; then
+    echo "Setup REPO_HOSTNAME=${REPO_HOSTNAME}"
+    BUILD_ARGS+=" --build-arg REPO_HOSTNAME=${REPO_HOSTNAME}"
+  fi
+
+  docker build -t ${IMAGE_NAME} ${BUILD_ARGS} . > ${DIR_TEST}/${BUILD_LOG} 2>&1
+
+  if [[ $? -ne 0 ]]
+  then
+    echo "ERROR: docker build failed for ${DISTRO}, see details from '${BUILD_LOG}'"
+    echo "== Log start for the docker build failure of ${DISTRO} =="
+    cat ${DIR_TEST}/${BUILD_LOG}
+    echo "== Log end for the docker build failure of ${DISTRO} =="
+  else
+    echo "Docker build for ${DISTRO} done"
+  fi
+
+  # Copying the build log to the COS bucket
+  if test -f ${DIR_TEST}/${BUILD_LOG}
+  then
+    echo "Build log for ${DISTRO} copied to the COS bucket"
+    cp ${DIR_TEST}/${BUILD_LOG} ${DIR_TEST_COS}
+  else
+    echo "No build log for ${DISTRO}"
+  fi
+
+  # Running the tests
+  echo "### ## Running the tests from the container: ${CONT_NAME} ## ###"
+  if [[ ! -z ${DOCKER_SECRET_AUTH+z} ]]
+  then
+    docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --env DOCKER_SECRET_AUTH --env DISTRO_NAME --env DISTRO_VERS --env PATH_SCRIPTS --env DIR_TEST --privileged --name ${CONT_NAME} ${IMAGE_NAME}
+  else
+    docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --env DISTRO_NAME --env DISTRO_VERS --env PATH_SCRIPTS --env DIR_TEST --privileged --name ${CONT_NAME} ${IMAGE_NAME}
+  fi
+
+  status_code="$(docker container wait $CONT_NAME)"
+  docker logs $CONT_NAME > ${DIR_TEST}/${TEST_LOG} 2>&1
+
+  if [[ ${status_code} -ne 0 ]]; then
+    echo "ERROR: The test suite failed for ${DISTRO}. See details from '${TEST_LOG}'"
+    echo "== Log start for the test failure of ${DISTRO} =="
+    cat ${DIR_TEST}/${TEST_LOG}
+    echo "== Log end for the test failure of ${DISTRO} =="
+  else
+    echo "Tests done"
+  fi
+
+  # Copying the test logs to the COS bucket
+  if test -f ${DIR_TEST}/${TEST_LOG}
+  then
+    echo "Test log for ${DISTRO} copied to the COS bucket"
+    cp ${DIR_TEST}/${TEST_LOG} ${DIR_TEST_COS}
+  else
+    echo "No test log for ${DISTRO}"
+  fi
+
+  if test -f ${DIR_TEST}/${TEST_JUNIT}
+  then
+    echo "Test junit copied to the COS bucket and ${ARTIFACTS}"
+    cp ${DIR_TEST}/${TEST_JUNIT} ${DIR_TEST_COS}
+    cp ${DIR_TEST}/${TEST_JUNIT} ${ARTIFACTS}
+  else
+    echo "No test junit for ${DISTRO}"
+  fi
+
+  popd
+  rm -rf tmp
+
+  end=$SECONDS
+  duration=$(expr $end - $begin)
+  echo "DURATION TEST ${DISTRO}: $(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+
+  # Check the logs and get in the errors.txt a summary of the error logs
+  echo "### ### # Checking the logs # ### ###"
+  echo "DISTRO ${DISTRO_NAME} ${DISTRO_VERS}" 2>&1 | tee -a ${PATH_ERRORS}
+
+  if test -f ${DIR_TEST}/${TEST_LOG} && [[ $(eval "cat ${DIR_TEST}/${TEST_LOG} | grep -c exitCode") == 4 ]]
+  then
+    echo "Dynamic packages" 2>&1 | tee -a ${PATH_ERRORS}
+    # We get 4 exitCodes in the log (3 tests + the output of the first containing exitCode)
+    TEST_1=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
+    TEST_2=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
+    TEST_3=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==4' | rev | cut -d' ' -f 1")
+  else
+    TEST_1=1
+    TEST_2=1
+    TEST_3=1
+  fi
+
+  echo "TestDistro : ${TEST_1}" 2>&1 | tee -a ${PATH_ERRORS}
+  echo "TestDistroInstallPackage : ${TEST_2}" 2>&1 | tee -a ${PATH_ERRORS}
+  echo "TestDistroPackageCheck : ${TEST_3}" 2>&1 | tee -a ${PATH_ERRORS}
+
+  [[ "$TEST_1" -eq "0" ]] && [[ "$TEST_2" -eq "0" ]] && [[ "$TEST_3" -eq "0" ]]
+  TEST=$?
+
+  # Copying the errors.txt to the COS bucket
+  cp ${PATH_ERRORS} ${PATH_ERRORS_COS}
+
+}#end: testDynamicPackages
+
+
+##
+# Test docker + containerd static packages
+# Set: $TEST_STATIC
+##
+testStaticPackages() {
+
+  DISTRO_NAME="alpine"
+
+  IMAGE_NAME_STATIC="t-static_docker_${DISTRO_NAME}"
+  CONT_NAME_STATIC="t-static_docker_run_${DISTRO_NAME}"
+  BUILD_LOG_STATIC="build-static_${DISTRO_NAME}.log"
+  TEST_LOG_STATIC="test-static_${DISTRO_NAME}.log"
+  TEST_JUNIT_STATIC="junit-tests-${DISTRO_NAME}.xml"
+
+  export DISTRO_NAME
+
+  # Get in the tmp directory and get the docker-ce and containerd packages and the Dockerfile in it
+  if ! test -d tmp
+  then
+    mkdir tmp
+  else
+    rm -rf tmp
+    mkdir tmp
+  fi
+  pushd tmp
+
+  echo "## Copying the static packages and the dockerfile for ${DISTRO_NAME} ##"
+  # Copy the static binaries
+  cp ${DIR_DOCKER}/docker-ppc64le.tgz .
+  # Copy the Dockerfile
+  cp ${PATH_DOCKERFILE}-static-alpine/Dockerfile .
+  # Copy the test-launch.sh
+  cp ${PATH_SCRIPTS}/test-launch.sh .
+  # Check if we have the static binaries and Dockerfile and the test-launch.sh
+  ls docker-ppc64le.tgz && ls Dockerfile && ls test-launch.sh
+  if [[ $? -ne 0 ]]
+  then
+    # The static binaries and/or the Dockerfile is/are missing
+    echo "The static binaries and/or the Dockerfile and/or the test-launch.sh is/are missing"
+  else
+    # Building the test image
+    echo "### Building the test image: ${IMAGE_NAME_STATIC} ###"
+    docker build -t ${IMAGE_NAME_STATIC} . > ${DIR_TEST}/${BUILD_LOG_STATIC} 2>&1
+
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR: docker build failed for ${DISTRO_NAME}, see details from '${BUILD_LOG_STATIC}'"
+    else
+      echo "Docker build done"
+    fi
+
+    # Copying the build log to the COS bucket
+    if test -f ${DIR_TEST}/${BUILD_LOG_STATIC}
+    then
+      echo "Build log for the static packages copied to the COS bucket"
+      cp ${DIR_TEST}/${BUILD_LOG_STATIC} ${DIR_TEST_COS}
+    else
+      echo "No build log for the static packages"
+    fi
+
+    # Running the tests
+    echo "### # Running the tests from the container: ${CONT_NAME_STATIC} # ###"
+    if [[ ! -z ${DOCKER_SECRET_AUTH+z} ]]
+    then
+      docker run -d --env DOCKER_SECRET_AUTH --env DISTRO_NAME --env PATH_SCRIPTS --env DIR_TEST -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --privileged --name ${CONT_NAME_STATIC} ${IMAGE_NAME_STATIC}
+    else
+      docker run -d --env DISTRO_NAME --env PATH_SCRIPTS --env DIR_TEST -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --privileged --name ${CONT_NAME_STATIC} ${IMAGE_NAME_STATIC}
+    fi
+
+    status_code="$(docker container wait ${CONT_NAME_STATIC})"
+    if [[ ${status_code} -ne 0 ]]; then
+      echo "ERROR: The test suite failed for ${DISTRO_NAME}. See details from '${TEST_LOG_STATIC}'"
+      docker logs ${CONT_NAME_STATIC} > ${DIR_TEST}/${TEST_LOG_STATIC} 2>&1
+    else
+      docker logs ${CONT_NAME_STATIC} > ${DIR_TEST}/${TEST_LOG_STATIC} 2>&1
+      echo "Tests done"
+    fi
+
+    # Copying the test logs to the COS bucket
+    if test -f ${DIR_TEST}/${TEST_LOG_STATIC}
+    then
+      echo "Test log for the static packages copied to the COS Bucket"
+      cp ${DIR_TEST}/${TEST_LOG_STATIC} ${DIR_TEST_COS}
+    else
+      echo "No test log for the static packages"
+    fi
+
+    if test -f ${DIR_TEST}/${TEST_JUNIT_STATIC}
+    then
+      echo "Test junit for the static packages copied to the COS bucket"
+      cp ${DIR_TEST}/${TEST_JUNIT_STATIC} ${DIR_TEST_COS}
+      cp ${DIR_TEST}/${TEST_JUNIT_STATIC} ${ARTIFACTS}
+    else
+      echo " No test junit for the static packages"
+    fi
+  fi
+  popd
+  rm -rf tmp
+
+  end=$SECONDS
+  duration=$(expr $end - $begin)
+  echo "DURATION test ${DISTRO_NAME}: $(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+
+  # Check the logs and get in the errors.txt a summary of the error logs
+  echo "### ### Checking the logs ### ###"
+
+  if test -f ${DIR_TEST}/${TEST_LOG_STATIC} && [[ $(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep -c exitCode") == 4 ]]
+  then
+    echo "Static binaries" 2>&1 | tee -a ${PATH_ERRORS}
+    # We get 4 exitCodes in the log (3 tests + the output of the first containing exitCode)
+    TEST_1_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
+    TEST_2_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
+    TEST_3_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==4' | rev | cut -d' ' -f 1")
+  else
+    TEST_1_STATIC=1
+    TEST_2_STATIC=1
+    TEST_3_STATIC=1
+  fi
+
+  echo "TestDistro : ${TEST_1_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
+  echo "TestDistroInstallPackage : ${TEST_2_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
+  echo "TestDistroPackageCheck : ${TEST_3_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
+
+  [[ "$TEST_1_STATIC" -eq "0" ]] && [[ "$TEST_2_STATIC" -eq "0" ]] && [[ "$TEST_3_STATIC" -eq "0" ]]
+  TEST_STATIC=$?
+
+}#end:testStaticPackages
+
+
+################################################################################
+# Main
+################################################################################
 
 DIR_TEST="/workspace/tests"
 export DIR_TEST
@@ -84,171 +391,7 @@ for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}
   do
-    begin=$SECONDS
-    echo "## Looking for ${DISTRO} ##"
-    DISTRO_NAME="$(cut -d'-' -f1 <<<"${DISTRO}")"
-    DISTRO_VERS="$(cut -d'-' -f2 <<<"${DISTRO}")"
-
-    # Get all environment variables
-    IMAGE_NAME="t_docker_${DISTRO_NAME}_${DISTRO_VERS}"
-    CONT_NAME="t_docker_run_${DISTRO_NAME}_${DISTRO_VERS}"
-    BUILD_LOG="build_${DISTRO_NAME}_${DISTRO_VERS}.log"
-    TEST_LOG="test_${DISTRO_NAME}_${DISTRO_VERS}.log"
-    TEST_JUNIT="junit-tests-${DISTRO_NAME}-${DISTRO_VERS}.xml"
-
-    export DISTRO_NAME
-    export DISTRO_VERS
-
-    # Get in the tmp directory and get the docker-ce and containerd packages and the Dockerfile in it
-    checkDirectory tmp
-    pushd tmp
-
-    cp ${PATH_DOCKERFILE}-${PACKTYPE}/Dockerfile .
-    cp ${PATH_SCRIPTS}/test-launch.sh .
-
-    ###
-    # Local test only: copy the packages that we just built
-    ###
-    if [[ "$TEST_MODE" = "local" ]]; then
-
-      echo "### Copying the packages and the dockerfile for ${DISTRO} ###"
-      # Copy the docker-ce packages
-      cp ${DIR_DOCKER}/bundles-ce-${DISTRO_NAME}-${DISTRO_VERS}-ppc64*.tar.gz .
-      # Copy the containerd packages (we have two different configurations depending on the package type)
-      CONTAINERD_VERS_2=$(echo ${CONTAINERD_VERS} | cut -d'v' -f2)
-      if [[ ${PACKTYPE} == "DEBS" ]]
-      then
-        # For the debian packages, we don't want the dbgsym package
-        cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io_${CONTAINERD_VERS_2}*_ppc64*.deb .
-      elif [[ ${PACKTYPE} == "RPMS" ]]
-      then
-        cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io-${CONTAINERD_VERS_2}*.ppc64*.rpm .
-      fi
-
-      # Check if we have the docker-ce and containerd packages and the Dockerfile and the test-launch.sh
-      ls bundles-ce-${DISTRO_NAME}-${DISTRO_VERS}-ppc64le.tar.gz && ls containerd*ppc64*.* && ls Dockerfile && ls test-launch.sh
-      if [[ $? -ne 0 ]]
-      then
-        # The docker-ce packages and/or the containerd packages and/or the Dockerfile is/are missing
-        echo "ERROR: The docker-ce packages and/or the containerd packages and/or the Dockerfile is/are missing"
-        continue
-      fi
-
-    fi
-
-    echo "### # Building the test image: ${IMAGE_NAME} # ###"
-    # Building the test image
-    if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8* ]]
-    then
-      ##
-      # Switch to quay.io for CentOS 8 stream
-      # See https://github.com/docker/containerd-packaging/pull/263
-      # See https://github.com/docker-library/official-images/pull/11831
-      ##
-      echo "Temporary fix: patching Dockerfile for using CentOS 8 stream and quay.io "
-      sed -i 's/FROM ppc64le.*/FROM quay.io\/centos\/centos\:stream8/g' Dockerfile
-    fi
-
-    BUILD_ARGS="--build-arg DISTRO_NAME=${DISTRO_NAME} --build-arg DISTRO_VERS=${DISTRO_VERS}"
-
-    if [[ "$TEST_MODE" = "staging" || "$TEST_MODE" = "release"  ]]; then
-      echo "Setup REPO_HOSTNAME=${REPO_HOSTNAME}"
-      BUILD_ARGS+=" --build-arg REPO_HOSTNAME=${REPO_HOSTNAME}"
-    fi
-
-    docker build -t ${IMAGE_NAME} ${BUILD_ARGS} . > ${DIR_TEST}/${BUILD_LOG} 2>&1
-
-    if [[ $? -ne 0 ]]
-    then
-      echo "ERROR: docker build failed for ${DISTRO}, see details from '${BUILD_LOG}'"
-      echo "== Log start for the docker build failure of ${DISTRO} =="
-      cat ${DIR_TEST}/${BUILD_LOG}
-      echo "== Log end for the docker build failure of ${DISTRO} =="
-    else
-      echo "Docker build for ${DISTRO} done"
-    fi
-
-    # Copying the build log to the COS bucket
-    if test -f ${DIR_TEST}/${BUILD_LOG}
-    then
-      echo "Build log for ${DISTRO} copied to the COS bucket"
-      cp ${DIR_TEST}/${BUILD_LOG} ${DIR_TEST_COS}
-    else
-      echo "No build log for ${DISTRO}"
-    fi
-
-    # Running the tests
-    echo "### ## Running the tests from the container: ${CONT_NAME} ## ###"
-    if [[ ! -z ${DOCKER_SECRET_AUTH+z} ]]
-    then
-      docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --env DOCKER_SECRET_AUTH --env DISTRO_NAME --env DISTRO_VERS --env PATH_SCRIPTS --env DIR_TEST --privileged --name ${CONT_NAME} ${IMAGE_NAME}
-    else
-      docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --env DISTRO_NAME --env DISTRO_VERS --env PATH_SCRIPTS --env DIR_TEST --privileged --name ${CONT_NAME} ${IMAGE_NAME}
-    fi
-
-    status_code="$(docker container wait $CONT_NAME)"
-    docker logs $CONT_NAME > ${DIR_TEST}/${TEST_LOG} 2>&1
-
-    if [[ ${status_code} -ne 0 ]]; then
-      echo "ERROR: The test suite failed for ${DISTRO}. See details from '${TEST_LOG}'"
-      echo "== Log start for the test failure of ${DISTRO} =="
-      cat ${DIR_TEST}/${TEST_LOG}
-      echo "== Log end for the test failure of ${DISTRO} =="
-    else
-      echo "Tests done"
-    fi
-
-    # Copying the test logs to the COS bucket
-    if test -f ${DIR_TEST}/${TEST_LOG}
-    then
-      echo "Test log for ${DISTRO} copied to the COS bucket"
-      cp ${DIR_TEST}/${TEST_LOG} ${DIR_TEST_COS}
-    else
-      echo "No test log for ${DISTRO}"
-    fi
-
-    if test -f ${DIR_TEST}/${TEST_JUNIT}
-    then
-      echo "Test junit copied to the COS bucket and ${ARTIFACTS}"
-      cp ${DIR_TEST}/${TEST_JUNIT} ${DIR_TEST_COS}
-      cp ${DIR_TEST}/${TEST_JUNIT} ${ARTIFACTS}
-    else
-      echo "No test junit for ${DISTRO}"
-    fi
-
-    popd
-    rm -rf tmp
-
-    end=$SECONDS
-    duration=$(expr $end - $begin)
-    echo "DURATION TEST ${DISTRO}: $(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
-
-    # Check the logs and get in the errors.txt a summary of the error logs
-    echo "### ### # Checking the logs # ### ###"
-    echo "DISTRO ${DISTRO_NAME} ${DISTRO_VERS}" 2>&1 | tee -a ${PATH_ERRORS}
-
-    if test -f ${DIR_TEST}/${TEST_LOG} && [[ $(eval "cat ${DIR_TEST}/${TEST_LOG} | grep -c exitCode") == 4 ]]
-    then
-      echo "Dynamic packages" 2>&1 | tee -a ${PATH_ERRORS}
-      # We get 4 exitCodes in the log (3 tests + the output of the first containing exitCode)
-      TEST_1=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
-      TEST_2=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
-      TEST_3=$(eval "cat ${DIR_TEST}/${TEST_LOG} | grep exitCode | awk 'NR==4' | rev | cut -d' ' -f 1")
-    else
-      TEST_1=1
-      TEST_2=1
-      TEST_3=1
-    fi
-
-    echo "TestDistro : ${TEST_1}" 2>&1 | tee -a ${PATH_ERRORS}
-    echo "TestDistroInstallPackage : ${TEST_2}" 2>&1 | tee -a ${PATH_ERRORS}
-    echo "TestDistroPackageCheck : ${TEST_3}" 2>&1 | tee -a ${PATH_ERRORS}
-
-    [[ "$TEST_1" -eq "0" ]] && [[ "$TEST_2" -eq "0" ]] && [[ "$TEST_3" -eq "0" ]]
-    TEST=$?
-
-    # Copying the errors.txt to the COS bucket
-    cp ${PATH_ERRORS} ${PATH_ERRORS_COS}
+    testDynamicPackages
   done
 done
 
@@ -256,124 +399,11 @@ done
 begin=$SECONDS
 echo "# Tests for the static packages #"
 
-DISTRO_NAME="alpine"
-
-IMAGE_NAME_STATIC="t-static_docker_${DISTRO_NAME}"
-CONT_NAME_STATIC="t-static_docker_run_${DISTRO_NAME}"
-BUILD_LOG_STATIC="build-static_${DISTRO_NAME}.log"
-TEST_LOG_STATIC="test-static_${DISTRO_NAME}.log"
-TEST_JUNIT_STATIC="junit-tests-${DISTRO_NAME}.xml"
-
-export DISTRO_NAME
-
-# Get in the tmp directory and get the docker-ce and containerd packages and the Dockerfile in it
-if ! test -d tmp
-then
-  mkdir tmp
+if [[ "$TEST_MODE" = "local" ]]; then
+  testStaticPackages
 else
-  rm -rf tmp
-  mkdir tmp
+  echo "Skip test static for TEST_MODE: $TEST_MODE"
 fi
-pushd tmp
-
-echo "## Copying the static packages and the dockerfile for ${DISTRO_NAME} ##"
-# Copy the static binaries
-cp ${DIR_DOCKER}/docker-ppc64le.tgz .
-# Copy the Dockerfile
-cp ${PATH_DOCKERFILE}-static-alpine/Dockerfile .
-# Copy the test-launch.sh
-cp ${PATH_SCRIPTS}/test-launch.sh .
-# Check if we have the static binaries and Dockerfile and the test-launch.sh
-ls docker-ppc64le.tgz && ls Dockerfile && ls test-launch.sh
-if [[ $? -ne 0 ]]
-then
-  # The static binaries and/or the Dockerfile is/are missing
-  echo "The static binaries and/or the Dockerfile and/or the test-launch.sh is/are missing"
-else
-  # Building the test image
-  echo "### Building the test image: ${IMAGE_NAME_STATIC} ###"
-  docker build -t ${IMAGE_NAME_STATIC} . > ${DIR_TEST}/${BUILD_LOG_STATIC} 2>&1
-
-  if [[ $? -ne 0 ]]; then
-    echo "ERROR: docker build failed for ${DISTRO_NAME}, see details from '${BUILD_LOG_STATIC}'"
-  else
-    echo "Docker build done"
-  fi
-
-  # Copying the build log to the COS bucket
-  if test -f ${DIR_TEST}/${BUILD_LOG_STATIC}
-  then
-    echo "Build log for the static packages copied to the COS bucket"
-    cp ${DIR_TEST}/${BUILD_LOG_STATIC} ${DIR_TEST_COS}
-  else
-    echo "No build log for the static packages"
-  fi
-
-  # Running the tests
-  echo "### # Running the tests from the container: ${CONT_NAME_STATIC} # ###"
-  if [[ ! -z ${DOCKER_SECRET_AUTH+z} ]]
-  then
-    docker run -d --env DOCKER_SECRET_AUTH --env DISTRO_NAME --env PATH_SCRIPTS --env DIR_TEST -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --privileged --name ${CONT_NAME_STATIC} ${IMAGE_NAME_STATIC}
-  else
-    docker run -d --env DISTRO_NAME --env PATH_SCRIPTS --env DIR_TEST -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} -v ${ARTIFACTS}:${ARTIFACTS} --privileged --name ${CONT_NAME_STATIC} ${IMAGE_NAME_STATIC}
-  fi
-
-  status_code="$(docker container wait ${CONT_NAME_STATIC})"
-  if [[ ${status_code} -ne 0 ]]; then
-    echo "ERROR: The test suite failed for ${DISTRO_NAME}. See details from '${TEST_LOG_STATIC}'"
-    docker logs ${CONT_NAME_STATIC} > ${DIR_TEST}/${TEST_LOG_STATIC} 2>&1
-  else
-    docker logs ${CONT_NAME_STATIC} > ${DIR_TEST}/${TEST_LOG_STATIC} 2>&1
-    echo "Tests done"
-  fi
-
-  # Copying the test logs to the COS bucket
-  if test -f ${DIR_TEST}/${TEST_LOG_STATIC}
-  then
-    echo "Test log for the static packages copied to the COS Bucket"
-    cp ${DIR_TEST}/${TEST_LOG_STATIC} ${DIR_TEST_COS}
-  else
-    echo "No test log for the static packages"
-  fi
-
-  if test -f ${DIR_TEST}/${TEST_JUNIT_STATIC}
-  then
-    echo "Test junit for the static packages copied to the COS bucket"
-    cp ${DIR_TEST}/${TEST_JUNIT_STATIC} ${DIR_TEST_COS}
-    cp ${DIR_TEST}/${TEST_JUNIT_STATIC} ${ARTIFACTS}
-  else
-    echo " No test junit for the static packages"
-  fi
-fi
-popd
-rm -rf tmp
-
-end=$SECONDS
-duration=$(expr $end - $begin)
-echo "DURATION test ${DISTRO_NAME}: $(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
-
-# Check the logs and get in the errors.txt a summary of the error logs
-echo "### ### Checking the logs ### ###"
-
-if test -f ${DIR_TEST}/${TEST_LOG_STATIC} && [[ $(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep -c exitCode") == 4 ]]
-then
-  echo "Static binaries" 2>&1 | tee -a ${PATH_ERRORS}
-  # We get 4 exitCodes in the log (3 tests + the output of the first containing exitCode)
-  TEST_1_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==2' | rev | cut -d' ' -f 1")
-  TEST_2_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==3' | rev | cut -d' ' -f 1")
-  TEST_3_STATIC=$(eval "cat ${DIR_TEST}/${TEST_LOG_STATIC} | grep exitCode | awk 'NR==4' | rev | cut -d' ' -f 1")
-else
-  TEST_1_STATIC=1
-  TEST_2_STATIC=1
-  TEST_3_STATIC=1
-fi
-
-echo "TestDistro : ${TEST_1_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
-echo "TestDistroInstallPackage : ${TEST_2_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
-echo "TestDistroPackageCheck : ${TEST_3_STATIC}" 2>&1 | tee -a ${PATH_ERRORS}
-
-[[ "$TEST_1_STATIC" -eq "0" ]] && [[ "$TEST_2_STATIC" -eq "0" ]] && [[ "$TEST_3_STATIC" -eq "0" ]]
-TEST_STATIC=$?
 
 [[ "$TEST" -eq "0" ]] && [[ "$TEST_STATIC" -eq "0" ]]
 echo "All : $?" 2>&1 | tee -a ${PATH_ERRORS}

--- a/test.sh
+++ b/test.sh
@@ -5,8 +5,8 @@
 # Usage: test.sh [local | staging | release]
 ##
 set -u
-
 set -o allexport
+
 source env.list
 
 # Function to create the directory if it does not exist
@@ -202,7 +202,7 @@ testDynamicPackages() {
   # Copying the errors.txt to the COS bucket
   cp ${PATH_ERRORS} ${PATH_ERRORS_COS}
 
-}#end: testDynamicPackages
+}
 
 
 ##
@@ -330,7 +330,7 @@ testStaticPackages() {
   [[ "$TEST_1_STATIC" -eq "0" ]] && [[ "$TEST_2_STATIC" -eq "0" ]] && [[ "$TEST_3_STATIC" -eq "0" ]]
   TEST_STATIC=$?
 
-}#end:testStaticPackages
+}
 
 
 ################################################################################
@@ -403,6 +403,7 @@ if [[ "$TEST_MODE" = "local" ]]; then
   testStaticPackages
 else
   echo "Skip test static for TEST_MODE: $TEST_MODE"
+  TEST_STATIC=0
 fi
 
 [[ "$TEST" -eq "0" ]] && [[ "$TEST_STATIC" -eq "0" ]]


### PR DESCRIPTION

- Cleanup traces for parallel docker build
- Add trigger files for the jobs postsubmit-test-docker-staging, postsubmit-test-docker-release
- Enable test for static packages only for local test mode
- Add new settings in env/env.list:
  * `DISABLE_DISTRO_DISCOVERY`: Disable linux distribution automatic discovery from the [docker-ce-packaging](https://github.com/docker/docker-ce-packaging) repo.
  This allows to manually  specify the distro list by settings the value for $RPMS and $DEBS.
  * `DISABLE_PUSH_COS`: Disable push of the packages to the COS bucket shared with Docker team
  * `COS_BUCKET_SHARED`, URL_COS_SHARED : COS bucket shared with Docker team settings
- Enable test for static packages only for local `test `mode (disable it for the other modes `staging` and `release`)