### PR TITLE
Fix typo on Docker version in env.list

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,5 +1,5 @@
 #Docker version
-DOCKER_VERS="20.10.14"
+DOCKER_VERS="v20.10.14"
 
 #Git ref for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:20.10


### PR DESCRIPTION
Made a typo for the  DOCKER_VERS="v20.10.14" in the env.list . The heading 'v' was missing.
