### PR TITLE
Fix side effect with Go version variable

### DIFF
--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -58,9 +58,9 @@ buildContainerd() {
   fi
 
   MAKE_OPTS="REF=${CONTAINERD_VERS}"
-  if [[ ! -z "${GOLANG_VERSION}" ]]
+  if [[ ! -z "${CONTAINERD_GO_VERSION}" ]]
   then
-    MAKE_OPTS+=" GOLANG_VERSION=${GOLANG_VERSION}"
+    MAKE_OPTS+=" GOLANG_VERSION=${CONTAINERD_GO_VERSION}"
   fi
 
   echo "Calling make ${MAKE_OPTS} ${TARGET}"

--- a/env/env.list
+++ b/env/env.list
@@ -18,7 +18,7 @@ CONTAINERD_PACKAGING_REF="825bb846ee12f0f0433c7289f1fcbd37040a91a1"
 RUNC_VERS=""
 
 #If not empty, specify the GO version for building containerd
-GOLANG_VERSION=""
+CONTAINERD_GO_VERSION=""
 
 ##
 # If '1' disable Linux distribution discovery from get-env.sh

--- a/env/env.list
+++ b/env/env.list
@@ -39,4 +39,4 @@ URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
 # This is useful when testing or debugging the script
 # and we do not want to publish the packages on the official repo
 ###
-DISABLE_PUSH_COS=0
+DISABLE_PUSH_COS=1


### PR DESCRIPTION
* Disable push to shared COS bucket (the script is broken).

* Rename GOLANG_VERSION shell variable to CONTAINERD_GO_VERSION
  
  The GOLANG_VERSION  variable is also used in containerd-packaging](https://github.com/docker/containerd-packaging/blob/825bb846ee12f0f0433c7289f1fcbd37040a91a1/common/common.mk#L22) and causing side effects, 
  When GOLANG_VERSION is set to "" in env.list, this was causing the  GOLANG_VERSION environment variable to be set to "" and made the build failing as the golang version was set to empty as depicted below:
  ```
  Building packages on docker.io/library/debian:bullseye
  
  containerd   : v1.5.11 (commit: 3df54a8)
  INFO: detected runc version (v1.0.3) from script/setup/runc-version
  runc         : v1.0.3 (commit: f46b6ba)
  architecture : ppc64le
  build image  : docker.io/library/debian:bullseye
  golang image : golang: <---The go version is missing here !!
  ```


