### PR TITLE
Build docker 20.10.15 and containerd 1.6.4

### DIFF
--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -46,7 +46,8 @@ buildContainerd() {
   DISTRO_VERS="$(cut -d'-' -f2 <<<"${DISTRO}")"
 
   TARGET="docker.io/library/${DISTRO_NAME}:${DISTRO_VERS}"
-  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8* ]]
+
+  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8 ]]
 	then
     ##
     # Switch to quay.io for CentOS 8 stream
@@ -55,6 +56,16 @@ buildContainerd() {
     echo "Switching to CentOS 8 stream and using quay.io"
 
     TARGET="quay.io/centos/centos:stream8"
+
+  elif [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:9 ]]
+	then
+    ##
+    # Switch to quay.io for CentOS 9 stream
+    # See https://github.com/docker/containerd-packaging/pull/283
+    ##
+    echo "Switching to CentOS 9 stream and using quay.io"
+
+    TARGET="quay.io/centos/centos:stream9"
   fi
 
   MAKE_OPTS="REF=${CONTAINERD_VERS}"

--- a/env/env.list
+++ b/env/env.list
@@ -39,4 +39,4 @@ URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
 # This is useful when testing or debugging the script
 # and we do not want to publish the packages on the official repo
 ###
-DISABLE_PUSH_COS=1
+DISABLE_PUSH_COS=0

--- a/env/env.list
+++ b/env/env.list
@@ -1,18 +1,18 @@
 #Docker version
-DOCKER_VERS="v20.10.14"
+DOCKER_VERS="v20.10.15"
 
 #Git ref for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:20.10
-DOCKER_PACKAGING_REF="33e8ce9d6cbe56678bb01ee55bd332abe34570dc"
+DOCKER_PACKAGING_REF="c55bd7a459b093ca9d78bbbe82a806750e889f94"
 
 #If '1' build containerd else reuse previously build
 CONTAINERD_BUILD="1"
 
 #Containerd version
-CONTAINERD_VERS="v1.5.11"
+CONTAINERD_VERS="v1.6.4"
 
 #Git ref for https://github.com/docker/containerd-packaging
-CONTAINERD_PACKAGING_REF="825bb846ee12f0f0433c7289f1fcbd37040a91a1"
+CONTAINERD_PACKAGING_REF="fd32fcdef58113383458926318c15a557ba0a59c"
 
 #Runc Version, if "" default runc will be used
 RUNC_VERS=""
@@ -40,5 +40,3 @@ URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
 # and we do not want to publish the packages on the official repo
 ###
 DISABLE_PUSH_COS=1
-
-# Test Build 2022-04-06

--- a/test.sh
+++ b/test.sh
@@ -90,7 +90,7 @@ testDynamicPackages() {
 
   echo "### # Building the test image: ${IMAGE_NAME} # ###"
   # Building the test image
-  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8* ]]
+  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8 ]]
   then
     ##
     # Switch to quay.io for CentOS 8 stream
@@ -99,6 +99,15 @@ testDynamicPackages() {
     ##
     echo "Temporary fix: patching Dockerfile for using CentOS 8 stream and quay.io "
     sed -i 's/FROM ppc64le.*/FROM quay.io\/centos\/centos\:stream8/g' Dockerfile
+
+  elif [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:9 ]]
+  then
+    ##
+    # Switch to quay.io for CentOS 8 stream
+    # See https://github.com/docker/containerd-packaging/pull/283
+    ##
+    echo "Temporary fix: patching Dockerfile for using CentOS 9 stream and quay.io "
+    sed -i 's/FROM ppc64le.*/FROM quay.io\/centos\/centos\:stream9/g' Dockerfile
   fi
 
   BUILD_ARGS="--build-arg DISTRO_NAME=${DISTRO_NAME} --build-arg DISTRO_VERS=${DISTRO_VERS}"


### PR DESCRIPTION
- Also fix for CentOS stream 9 that must be retrieved from quay.io (not available docker hub)
- Enable push to COS