### PR TITLE
Spin test staging for docker 20.10.15, containerd 1.6.4, 2d attempt

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
 # Update this file to spwan the prow job postsubmit-test-docker-staging
-# Version 20.10.16 / 1.6.4
+# Version 20.10.16 / 1.6.4, 2d attempt


### PR DESCRIPTION
Spinning the test staging job again, as the 1st failed because of COS bucket access failure.
See https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/postsubmit-test-docker-staging/1527688752099495936

```
+ /home/prow/go/src/github.com/ppc64le-cloud/docker-ce-build/get-env-containerd.sh
cp: cannot access '/mnt/s3_ppc64le-docker/prow-docker/dockertest': Software caused connection abort
...
Build log for debian-bullseye copied to the COS bucket
+ cp /workspace/tests/build_debian_bullseye.log /mnt/s3_ppc64le-docker/prow-docker/build-docker-v20.10.16_180522-1607/tests-staging
cp: failed to access '/mnt/s3_ppc64le-docker/prow-docker/build-docker-v20.10.16_180522-1607/tests-staging': Transport endpoint is not connected
+ echo '### ## Running the tests from the container: t_docker_run_debian_bullseye ## ###'
```