### PR TITLE
Add failpoint setup script

### DIFF
--- a/test-containerd/test_on_powervs.sh
+++ b/test-containerd/test_on_powervs.sh
@@ -52,6 +52,7 @@ fi
 
 script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
 script/setup/install-critools
+script/setup/install-failpoint-binaries
 script/setup/install-gotestsum
 unset GOFLAGS
 


### PR DESCRIPTION
Run script/setup/install-failpoint-binaries script before running containerd tests to allow TestRunPodSandboxWithSetupCNIFailure and TestRunPodSandboxWithShimStartFailure tests to run properly