### PR TITLE
Fix gotestsum error for the docker packaging tests

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,15 +1,17 @@
 # New version of containerd: 1.6.7 (with runc 1.1.3 & go 1.17.13)
 # New parallel algorithm for building Docker and Building/Testing containerd.
 
-#Docker reference (tag) 
+#Docker reference (tag)
 DOCKER_REF="v20.10.17"
 
 #Git ref for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:20.10
 DOCKER_PACKAGING_REF="448d90a2cbf44a8ad2bbd038f6370855dfebf4c4"
 
-#If '1' build containerd else reuse previously build
-# or calling test local for debugging purpose
+#If '1', build containerd (default)
+#If '0', a previously build version of containerd will be used for the 'local' test
+# The containerd packages are retrieved from the COS bucket such as below:
+#  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
 CONTAINERD_BUILD="0"
 
 #Containerd reference (tag)

--- a/env/env.list
+++ b/env/env.list
@@ -12,7 +12,7 @@ DOCKER_PACKAGING_REF="448d90a2cbf44a8ad2bbd038f6370855dfebf4c4"
 #If '0', a previously build version of containerd will be used for the 'local' test
 # The containerd packages are retrieved from the COS bucket such as below:
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
-CONTAINERD_BUILD="0"
+CONTAINERD_BUILD="1"
 
 #Containerd reference (tag)
 CONTAINERD_REF="v1.6.7"

--- a/env/env.list
+++ b/env/env.list
@@ -9,7 +9,8 @@ DOCKER_REF="v20.10.17"
 DOCKER_PACKAGING_REF="448d90a2cbf44a8ad2bbd038f6370855dfebf4c4"
 
 #If '1' build containerd else reuse previously build
-CONTAINERD_BUILD="1"
+# or calling test local for debugging purpose
+CONTAINERD_BUILD="0"
 
 #Containerd reference (tag)
 CONTAINERD_REF="v1.6.7"

--- a/get-env-containerd.sh
+++ b/get-env-containerd.sh
@@ -51,7 +51,7 @@ if [[ ${CONTAINERD_BUILD} = "0" ]]
 then
     echo "CONTAINERD_BUILD is set to 0, we copy the containerd packages from the COS bucket"
     mkdir /workspace/containerd-${CONTAINERD_REF}_${DATE}
-    cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/containerd-${CONTAINERD_REF} /workspace/containerd-${CONTAINERD_REF}_${DATE}
+    cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/containerd-${CONTAINERD_REF}/* /workspace/containerd-${CONTAINERD_REF}_${DATE}
 else
     echo "CONTAINERD_BUILD is set to 1"
 fi

--- a/prow-test-docker.sh
+++ b/prow-test-docker.sh
@@ -5,14 +5,15 @@ set -x
 
 ##
 # Set the test mode:
+# - local, test with packages from COS bucket
 # - staging, test from the docker's staging download website
 # - release, form docker's official public download website
 ##
 TEST_MODE="${1:-staging}"
 
 echo "TEST_MODE=${TEST_MODE}"
-if [[ "$TEST_MODE" != "staging" && "$TEST_MODE" != "release" ]]; then
-    echo "Usage: staging | release"
+if [[ "$TEST_MODE" != "local" && "$TEST_MODE" != "staging" && "$TEST_MODE" != "release" ]]; then
+    echo "Usage: local | staging | release"
     exit 2
 fi
 

--- a/test-launch.sh
+++ b/test-launch.sh
@@ -21,6 +21,9 @@ export GO111MODULE=auto
 cd /workspace/test/src/github.ibm.com/powercloud/dockertest
 go install gotest.tools/gotestsum@v1.7.0
 
+echo "* Go version:"
+go version
+
 if [[ ${DISTRO_NAME} == "alpine" ]]
 then
   gotestsum --format standard-verbose --junitfile ${DIR_TEST}/junit-tests-${DISTRO_NAME}.xml --debug -- ./tests/${DISTRO_NAME}

--- a/test.sh
+++ b/test.sh
@@ -63,6 +63,13 @@ testDynamicPackages() {
   pushd tmp-${DISTRO}
 
   cp ${PATH_DOCKERFILE}-${PACKTYPE}/Dockerfile .
+
+  # Workaround for builkit cache issue
+  # See https://github.com/moby/buildkit/issues/1368
+  PWD=`pwd`
+  echo "Debug: Touching $PWD/Dockerfile"
+  touch Dockerfile
+
   cp ${PATH_SCRIPTS}/test-launch.sh .
 
   ###


### PR DESCRIPTION
* Fix issue  #52 by adding a touch to the Dockerfiles used for launching the tests.
 This changes the timestamp of the Dockerfile, which makes Docker consider those Dockerfiles different from each other and do not  reuse any cached data when building the test images.
* Also fix the use of  CONTAINERD_BUILD=0 and provided usage comment in env/env/list
*  Added a `local` option to prow-test-docker.sh, so that we can re-test the packages by grabbing them from the COS bucket