### PR TITLE
Build docker 20.10.18 and containerd 1.6.8

### DIFF
--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -141,6 +141,12 @@ then
   git fetch origin ${CONTAINERD_PACKAGING_REF}
   git checkout FETCH_HEAD
 
+
+  if [[ ! -z "${CONTAINERD_RUNC_REF}" ]]
+  then
+    export RUNC_REF=${CONTAINERD_RUNC_REF}
+  fi
+
   make REF=${CONTAINERD_REF} checkout
 fi
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -54,6 +54,17 @@ patchDockerFiles() {
   done
 }
 
+##
+# Patch GO image so that we use bullseye instead of buster which is EOL
+# For instance the golang:1.18.6-buster is only supported for x86
+##
+patchGoVersion() {
+  MKFILE_PATH=$1/Makefile
+
+  echo "Patching GO image from buster to bullseye for $MKFILE_PATH"
+  sed -ri  's/GO_VERSION\)\-buster/GO_VERSION\)\-bullseye/' $MKFILE_PATH
+}
+
 # Function to build docker packages
 # $1 : distro
 # $2 : DEBS or RPMS
@@ -110,6 +121,9 @@ patchDockerFiles .
 cd /workspace/docker-ce-packaging/rpm
 patchDockerFiles .
 cd /workspace
+
+patchGoVersion /workspace/docker-ce-packaging/deb
+patchGoVersion /workspace/docker-ce-packaging/rpm
 
 before=$SECONDS
 # 1) Build the list of distros

--- a/env/env.list
+++ b/env/env.list
@@ -20,8 +20,11 @@ CONTAINERD_REF="v1.6.8"
 #Git ref for https://github.com/docker/containerd-packaging
 CONTAINERD_PACKAGING_REF="f4f1c98ba7f180b9aa4f48f58dfec16d66c333fa"
 
-#Runc Version, if "" default runc will be used
+#Runc Version, if "" default runc will be used for the static build
 RUNC_VERS="1.1.3"
+
+#If not empty, specify the RUNC version for building containerd
+CONTAINERD_RUNC_REF="v1.1.4"
 
 #If not empty, specify the GO version for building containerd
 CONTAINERD_GO_VERSION="1.17.13"

--- a/env/env.list
+++ b/env/env.list
@@ -1,12 +1,12 @@
-# New version of containerd: 1.6.7 (with runc 1.1.3 & go 1.17.13)
-# New parallel algorithm for building Docker and Building/Testing containerd.
+# New version of containerd: 1.6.8 (with runc 1.1.4 & go 1.17.13)
+# New version of docker: 20.10.18
 
 #Docker reference (tag)
-DOCKER_REF="v20.10.17"
+DOCKER_REF="v20.10.18"
 
 #Git ref for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:20.10
-DOCKER_PACKAGING_REF="448d90a2cbf44a8ad2bbd038f6370855dfebf4c4"
+DOCKER_PACKAGING_REF="aad0dc4a2252b9cc11d647b1bf2159e6b5cf351d"
 
 #If '1', build containerd (default)
 #If '0', a previously build version of containerd will be used for the 'local' test
@@ -15,10 +15,10 @@ DOCKER_PACKAGING_REF="448d90a2cbf44a8ad2bbd038f6370855dfebf4c4"
 CONTAINERD_BUILD="1"
 
 #Containerd reference (tag)
-CONTAINERD_REF="v1.6.7"
+CONTAINERD_REF="v1.6.8"
 
 #Git ref for https://github.com/docker/containerd-packaging
-CONTAINERD_PACKAGING_REF="cb0d2c20bc815d09c407ba6481f2c4b8da03af79"
+CONTAINERD_PACKAGING_REF="f4f1c98ba7f180b9aa4f48f58dfec16d66c333fa"
 
 #Runc Version, if "" default runc will be used
 RUNC_VERS="1.1.3"
@@ -45,5 +45,4 @@ URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
 # This is useful when testing or debugging the script
 # and we do not want to publish the packages on the official repo
 ###
-#TODO DO NOT forget to enable Push to COS again for next official build (set DISABLE_PUSH_COS=0)
-DISABLE_PUSH_COS=1
+DISABLE_PUSH_COS=0


### PR DESCRIPTION
- Override runc version to v1.1.4 for containerd, RUNC_REF
- Patch Go image to bullseye in build-docker.sh due to Debian bullesye EOL
- Update env.list for building docker 20.10.18 and containerd 1.6.8