### PR TITLE
Powervs Memory Increase

### DIFF
--- a/test-containerd/instanciate_powervs_vm.sh
+++ b/test-containerd/instanciate_powervs_vm.sh
@@ -73,6 +73,8 @@ IP=$(ibmcloud pi in $ID | grep -Eo "External Address:[[:space:]]*[0-9.]+" | cut 
 
 # Check if the server is up
 # Typical time needed: 1 to 3 minutes
+sleep 150
+
 TIMEOUT=10
 i=0
 mkdir -p ~/.ssh

--- a/test-containerd/instanciate_powervs_vm.sh
+++ b/test-containerd/instanciate_powervs_vm.sh
@@ -47,7 +47,7 @@ if [ -z $NETWORK ]; then echo "FAIL: Network not fulfilled."; usage; exit 1; fi
 
 # Create a machine
 # Sometime fail, but the machine is correctly instanciated
-ibmcloud pi instance-create $NAME --image ubuntu_2004_containerd --key-name $SSH_KEY --memory 2 --processor-type shared --processors '0.25' --network $NETWORK --storage-type tier3 || true
+ibmcloud pi instance-create $NAME --image ubuntu_2004_containerd --key-name $SSH_KEY --memory 8 --processor-type shared --processors '0.5' --network $NETWORK --storage-type tier3 || true
 
 # Wait it is registred
 sleep 120

--- a/test-containerd/test_on_powervs.sh
+++ b/test-containerd/test_on_powervs.sh
@@ -54,6 +54,7 @@ script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print
 script/setup/install-critools
 script/setup/install-failpoint-binaries
 script/setup/install-gotestsum
+script/setup/config-containerd
 unset GOFLAGS
 
 export GOPROXY="direct"
@@ -64,13 +65,14 @@ make binaries GO_BUILD_FLAGS="-mod=vendor"
 make install
 unset CGO_ENABLED
 
+echo "==== INTEGRATION TEST ===="
+GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-integration1_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" make integration $TEST_FLAG TESTFLAGS_RACE=-race
+GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-integration2_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" TESTFLAGS_PARALLEL=1 make integration $TEST_FLAG
+GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-cri-integration_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" CONTAINERD_RUNTIME=$TEST_RUNTIME make cri-integration
+
 echo "==== TEST ===="
 GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-simple_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" make test
 echo "==== ROOT-TEST ===="
 GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-root_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.parallel 1 -test.timeout 30m" make root-test
 
-echo "==== INTEGRATION TEST ===="
-GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-integration1_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" make integration $TEST_FLAG TESTFLAGS_RACE=-race
-GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-integration2_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" TESTFLAGS_PARALLEL=1 make integration $TEST_FLAG
-GOTEST='gotestsum --' GOTESTSUM_JUNITFILE="junit_test-cri-integration_$RUNC_FLAVOR-$TEST_RUNTIME.xml" EXTRA_TESTFLAGS="-test.timeout 30m" CONTAINERD_RUNTIME=$TEST_RUNTIME make cri-integration
 echo "==== END $RUNC_FLAVOR RUNTIME $TEST_RUNTIME ===="


### PR DESCRIPTION
Containerd integration test suite failures on PowerVS are fixed by increasing the allocated memory and processor resources and adding some additional configuration before test suites are executed.