### PR TITLE
Re-build/test now that static build failure fixed

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,5 +1,5 @@
-# New version of containerd: 1.6.8 (with runc 1.1.4 & go 1.17.13)
-# New version of docker: 20.10.18  
+# New version of containerd: 1.6.8  (using runc 1.1.4 & go 1.17.13 (Sebastiaan)
+# New version of docker:   20.10.18 (using              go 1.18.6 (automatic?))
 
 #Docker reference (tag)
 DOCKER_REF="v20.10.18"
@@ -21,7 +21,7 @@ CONTAINERD_REF="v1.6.8"
 CONTAINERD_PACKAGING_REF="f4f1c98ba7f180b9aa4f48f58dfec16d66c333fa"
 
 #Runc Version, if "" default runc will be used for the static build
-RUNC_VERS="1.1.3"
+RUNC_VERS="1.1.4"
 
 #If not empty, specify the RUNC version for building containerd
 CONTAINERD_RUNC_REF="v1.1.4"


### PR DESCRIPTION
Docker version 20.10.18 requires Runc 1.1.4 and containerd 1.6.8
Containerd version 1.6.8 requires Runc 1.1.4 and Go 1.17.13