### PR TITLE
Increase wait time before attempting ssh

### DIFF
--- a/test-containerd/instantiate_vm_and_test.sh
+++ b/test-containerd/instantiate_vm_and_test.sh
@@ -72,8 +72,7 @@ if [ "$i" == "$TIMEOUT" ]; then echo "FAIL: fail to get IP" ; exit 1; fi
 IP=$(ibmcloud pi in $ID | grep -Eo "External Address:[[:space:]]*[0-9.]+" | cut -d ' ' -f3)
 
 # Check if the server is up
-# Typical time needed: 1 to 3 minutes
-sleep 150
+sleep 360
 
 TIMEOUT=10
 i=0


### PR DESCRIPTION
Increase wait time to 6 minutes before attempting to access a new VM via ssh.