### PR TITLE
Fix vm networking

### DIFF
--- a/test-containerd/instantiate_vm_and_test.sh
+++ b/test-containerd/instantiate_vm_and_test.sh
@@ -90,7 +90,7 @@ while [ $i -lt $TIMEOUT ] && [ -z "$(ibmcloud pi in $ID | grep 'External Address
   sleep 60
 done
 # Fail to connect
-if [ "$i" == "$TIMEOUT" ]; then echo "FAIL: fail to get IP" ; delete_vm $ID; delete_network $NETWORK; exit 1; fi
+if [ "$i" == "$TIMEOUT" ]; then echo "FAIL: fail to get IP" ; delete_vm $ID; sleep 120; delete_network $NETWORK; exit 1; fi
 
 IP=$(ibmcloud pi in $ID | grep -Eo "External Address:[[:space:]]*[0-9.]+" | cut -d ' ' -f3)
 
@@ -119,7 +119,7 @@ if [ "$i" == "$TIMEOUT" ]; then
     sleep 60
   done
   # Fail again to connect
-  if [ "$j" == "$TIMEOUT" ]; then echo "FAIL: fail to connect to the VM" ; delete_vm $ID; delete_network $NETWORK; exit 1; fi
+  if [ "$j" == "$TIMEOUT" ]; then echo "FAIL: fail to connect to the VM" ; delete_vm $ID; sleep 120; delete_network $NETWORK; exit 1; fi
 fi
 
 # Get test script and execute it

--- a/test-containerd/instantiate_vm_and_test.sh
+++ b/test-containerd/instantiate_vm_and_test.sh
@@ -128,4 +128,5 @@ ssh ubuntu@$IP -i /etc/ssh-volume/ssh-privatekey sudo bash test_on_powervs.sh $R
 scp -i /etc/ssh-volume/ssh-privatekey "ubuntu@$IP:/home/containerd_test/containerd/*.xml" ${OUTPUT}
 
 delete_vm $ID
+sleep 120
 delete_network $NETWORK

--- a/test-containerd/instantiate_vm_and_test.sh
+++ b/test-containerd/instantiate_vm_and_test.sh
@@ -69,7 +69,7 @@ NAME="$NAME-$RAND_VAL"
 
 # Create public network for VM
 NETNAME="prow-net-$RAND_VAL"
-NETWORK=$(ibmcloud pi netcpu $NETNAME | grep -m 1 ID | awk '{print $2}') || true
+NETWORK=$(ibmcloud pi netcpu $NETNAME --dns-servers "9.9.9.9" | grep -m 1 ID | awk '{print $2}') || true
 
 if [ -z "$NETWORK" ]; then echo "FAIL: fail to configure network."; exit 1; fi
 

--- a/test-containerd/instantiate_vm_and_test.sh
+++ b/test-containerd/instantiate_vm_and_test.sh
@@ -60,7 +60,6 @@ done
 # Ensure key, name and network are fulfilled
 if [ -z $SSH_KEY ]; then echo "FAIL: Key not fulfilled."; usage; exit 1; fi
 if [ -z $NAME ]; then echo "FAIL: Name not fulfilled."; usage; exit 1; fi
-# if [ -z $NETWORK ]; then echo "FAIL: Network not fulfilled."; usage; exit 1; fi
 
 # Create a machine
 # Sometime fail, but the machine is correctly instanciated


### PR DESCRIPTION
A new public network will be created for new PowerVS instances at the start of each test. New PowerVS instances will no longer depend on an existing public network.