### PR TITLE
Retest Docker 23.0.0 in staging

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
 # Update this file to spawn the prow job postsubmit-test-docker-staging
-# Version 23.0.0 / 1.6.16 
+# Version 23.0.0 / 1.6.16


### PR DESCRIPTION
Retest Docker 23.0.0 in staging due to Fedora 37 test timeout.