### PR TITLE
Display an error message and exit when copying to COS bucket fails.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -14,6 +14,9 @@ checkDirectory() {
   if ! test -d $1
   then
     mkdir $1
+    if [[ $? -ne 0 ]]; then
+      exit 1
+    fi
     echo "$1 created"
   else
     echo "$1 already created"


### PR DESCRIPTION
This change will display an error message in case the script cannot create a directory to copy builds to on the COS bucket due to any reason.