### PR TITLE
Introduced DOCKER_BUILD env var which when unset will only build

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -6,6 +6,10 @@ set -u
 set -o allexport
 source env.list
 
+#If DOCKER_BUILD is set to 1, build Docker, otherwise don't
+if [ $DOCKER_BUILD == 0 ]; then
+  exit 0
+fi
 NCPUs=`grep processor /proc/cpuinfo | wc -l`
 echo "Nber of available CPUs: ${NCPUs}"
 

--- a/env/env.list
+++ b/env/env.list
@@ -8,11 +8,14 @@ DOCKER_REF="v23.0.2"
 # We are currently on the branch:20.10
 DOCKER_PACKAGING_REF="1a8fcfed5a6ce5c6edc6a89a372f01283bf9aee3"
 
+#If '1', build Docker (default)
+DOCKER_BUILD="0"
+
 #If '1', build containerd (default) 
 #If '0', a previously build version of containerd will be used for the 'local' test
 # The containerd packages are retrieved from the COS bucket such as below:
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
-CONTAINERD_BUILD="0"
+CONTAINERD_BUILD="1"
 
 #Containerd reference (tag)
 CONTAINERD_REF="v1.6.18"


### PR DESCRIPTION
Introduced DOCKER_BUILD env var which when unset will only build containerd and will build both, docker and containerd when set.