### PR TITLE
Fix Automatic Pushing of Builds to shared COS bucket

### DIFF
--- a/check-tests.sh
+++ b/check-tests.sh
@@ -31,15 +31,22 @@ echo "Nb of test logs : ${NB_TEST_LOGS}"
 
 
 DISTROS=$(eval "echo $DEBS $RPMS | tr '-' '_'")
-
 if [[ "$TEST_MODE" = "local" ]]; then
   DISTROS+=" alpine"
 else
   echo "Skip test static for TEST_MODE: $TEST_MODE"
 fi
-
 echo "List of distros : ${DISTROS}"
 NB_DISTROS=$(eval "echo ${DISTROS} | wc -w")
+
+# Reduce count of expected successful builds by one for each end of life 
+# distribution encountered, as end of life distributions will not be built successfully.
+for EXCLUSION in "${EXCLUSIONS[@]}"; do
+        echo ${DISTROS} | grep -i "${EXCLUSION}"
+               if [[ $? == 0 ]]; then
+                       NB_DISTROS=$(( $NB_DISTROS - 1 ))
+                fi
+done
 echo "Nb of distros : ${NB_DISTROS}"
 
 if [[ ${NB_BUILD_LOGS} == ${NB_DISTROS} ]] && [[ ${NB_TEST_LOGS} == ${NB_DISTROS} ]]

--- a/env/env.list
+++ b/env/env.list
@@ -45,7 +45,7 @@ DISABLE_DISTRO_DISCOVERY=0
 ##
 COS_BUCKET_SHARED="ibm-docker-builds"
 URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
-
+EXCLUSIONS+=( "ubuntu_impish" "debian_buster" "alpine" )
 ##
 #  If '1' disable push to shared COS
 # This is useful when testing or debugging the script


### PR DESCRIPTION
Certain distributions have reached end of life and are yet discovered by the code from the upstream repository. This commit helps the code skip through those distributions. This is being done to fix an issue where the packages do not get automatically pushed to the shared COS bucket as the code refuses to copy over any packages if there is any error thrown at any point through the build process.