### PR TITLE
Only perform tests if Docker packages are built and not otherwise.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -7,7 +7,8 @@ set -o allexport
 source env.list
 
 #If DOCKER_BUILD is set to 1, build Docker, otherwise don't
-if [ $DOCKER_BUILD == 0 ]; then
+if [[ ${DOCKER_BUILD} == 0 ]]; then
+  echo "DOCKER_BUILD is set to 0. Skipping building of docker packages."
   exit 0
 fi
 NCPUs=`grep processor /proc/cpuinfo | wc -l`

--- a/prow-build-test-containerd.sh
+++ b/prow-build-test-containerd.sh
@@ -40,6 +40,11 @@ ${PATH_SCRIPTS}/build-containerd.sh
 exit_code_build=$?
 echo "Exit code build : ${exit_code_build}"
 
+if [[ ${DOCKER_BUILD} == 0 ]]; then
+  echo "INFO: Skipping tests as docker packages have not been built."
+  exit 0
+fi
+
 # Test the packages
 echo "*** * Tests * ***"
 ${PATH_SCRIPTS}/test.sh


### PR DESCRIPTION
If DOCKER_BUILD is set to 0, Docker packages are not built and hence tests should not be performed as these packages will not be found. This pull request skips these tests if DOCKER_BUILD is set to 0.