### PR TITLE
Skip tests if CONTAINERD_BUILD is set to 0

### DIFF
--- a/prow-build-docker.sh
+++ b/prow-build-docker.sh
@@ -47,6 +47,11 @@ then
     exit 1
 fi
 
+#Docker tests require containerd packages to be built.
+if [[ ${CONTAINERD_BUILD} == 0 ]];then
+    echo "CONTAINERD_BUILD is set to 0. Skipping tests as containerd was not built."
+    exit 0
+fi
 
 echo "Triggering the next prow job using git commit"
 TRACKING_REPO=${REPO_OWNER}/${REPO_NAME}


### PR DESCRIPTION
All tests defined in https://github.com/ppc64le-cloud/docker-ce-build/blob/main/test.sh fail e.g. [here](https://s3.us-south.cloud-object-storage.appdomain.cloud/ppc64le-prow-logs/logs/postsubmit-build-test-containerd/1645363057297199104/build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=d5b0d1e12bb74ec5b0cca25bec3e0746%2F20230410%2Fus-south%2Fs3%2Faws4_request&X-Amz-Date=20230410T142635Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=496c4eb33fe129788b0ef8d760068c376b59dd104d4ca9bae832ba908904292e) if containerd is not built. Hence, if we are only building Docker and not containerd, these tests should not be performed.