### PR TITLE
Build Docker v20.10.24 and containerd v.1.6.20

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -15,7 +15,7 @@ DOCKER_BUILD="1"
 #If '0', a previously build version of containerd will be used for the 'local' test
 # The containerd packages are retrieved from the COS bucket such as below:
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
-CONTAINERD_BUILD="0"
+CONTAINERD_BUILD="1"
 
 #Containerd reference (tag)
 CONTAINERD_REF="v1.6.20"


### PR DESCRIPTION
Building Docker v20.10.24 and containerd v1.6.20 simultaneously to let tests run successfully.