### PR TITLE
Retest Docker v20.10.24 in release

### DIFF
--- a/env/test-release.list
+++ b/env/test-release.list
@@ -1,2 +1,2 @@
 # Update this file to spwan the prow job postsubmit-test-docker-release 
-# Version 20.10.24 / 1.6.20
+# Version 20.10.24 / 1.6.20 


### PR DESCRIPTION
Retesting Docker v20.10.24 in release as the Docker daemon did not start resulting in test failures for some distributions.