### PR TITLE
Testing PR 90: Fix push COS

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -2,7 +2,7 @@
 # New version of docker:  23.0.1 (using containerd 1.6.15) 
 
 #Docker reference (tag)
-DOCKER_REF="v20.10.24" 
+DOCKER_REF="v20.10.24"
 
 #Git ref for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:20.10


### PR DESCRIPTION
Rebuilding Docker v20.10.24 to test https://github.com/ppc64le-cloud/docker-ce-build/pull/90.