### PR TITLE
Retest Docker 23.0.4 in staging

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
 #  Update this file to spawn the prow job postsubmit-test-docker-staging
-# Version 23.0.4 / 1.6.20
+# Version 23.0.4 / 1.6.20 


### PR DESCRIPTION
Retesting Docker v23.0.4 in staging due to several test failures (network problems and Docker Daemon did not start)