### PR TITLE
Retain VM when SSH fails

### DIFF
--- a/test-containerd/instantiate_vm_and_test.sh
+++ b/test-containerd/instantiate_vm_and_test.sh
@@ -121,7 +121,8 @@ if [ "$i" == "$TIMEOUT" ]; then
     sleep 60
   done
   # Fail again to connect
-  if [ "$j" == "$TIMEOUT" ]; then echo "FAIL: fail to connect to the VM" ; delete_vm $ID; sleep 120; delete_network $NETWORK; exit 1; fi
+  # if [ "$j" == "$TIMEOUT" ]; then echo "FAIL: fail to connect to the VM" ; delete_vm $ID; sleep 120; delete_network $NETWORK; exit 1; fi
+  if [ "$j" == "$TIMEOUT" ]; then echo "FAIL: fail to connect to the VM" ; exit 1; fi
 fi
 
 # Get test script and execute it


### PR DESCRIPTION
Do not delete the test instance when SSH fails. This will allow for further investigation and testing into connection issues.