### PR TITLE
Check for alpine tests only during local tests

### DIFF
--- a/check-tests.sh
+++ b/check-tests.sh
@@ -47,8 +47,13 @@ for EXCLUSION in "${EXCLUSIONS[@]}"; do
                        NB_DISTROS=$(( $NB_DISTROS - 1 ))
                 fi
 done
-echo "Nb of distros : ${NB_DISTROS}"
 
+# Alpine build is tested only during local tests.
+if [[ "$TEST_MODE" = "local" ]]; then
+  NB_DISTROS=$(( $NB_DISTROS + 1 ))
+fi
+
+echo "Nb of distros : ${NB_DISTROS}"
 if [[ ${NB_BUILD_LOGS} == ${NB_DISTROS} ]] && [[ ${NB_TEST_LOGS} == ${NB_DISTROS} ]]
 then
     echo "~ Check the file ~"


### PR DESCRIPTION
Static tests of Docker builds for Linux Alpine are only performed during local tests. Hence, increment one to the number of distributions which has been decremented an additional one time for Alpine since it is under "Exclusions". However, during local tests, Linux Alpine is not to be excluded.