### PR TITLE
Build Docker 23.0.5

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -15,7 +15,7 @@ DOCKER_BUILD="1"
 #If '0', a previously build version of containerd will be used for the 'local' test
 # The containerd packages are retrieved from the COS bucket such as below:
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
-CONTAINERD_BUILD="0"
+CONTAINERD_BUILD="1"
 
 #Containerd reference (tag)
 CONTAINERD_REF="v1.6.20"


### PR DESCRIPTION
Build Docker v23.0.5 and temporarily build the latest containerd packages as well because if they are not built, all tests fail.