### PR TITLE
Retest Docker v23.0.5 in staging

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
 #  Update this file to spawn the prow job postsubmit-test-docker-staging
-# Version 23.0.5 / 1.6.20 
+# Version 23.0.5 / 1.6.20


### PR DESCRIPTION
Retesting Docker v23.0.5 in staging as containerd.io could not be found by yum while testing Fedora 38.