### PR TITLE
Test staging Docker v23.0.5

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
 #  Update this file to spawn the prow job postsubmit-test-docker-staging
-# Version 23.0.5 / 1.6.21
+# Version 23.0.5 / 1.6.21 


### PR DESCRIPTION
Running staging tests on Docker v23.0.5 again. The last time containerd packages were not available for Fedora 38 resulting in test failures. Containerd for Fedora 38 is now available.