### PR TITLE
Rebuild Docker v24.0.2

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,5 +1,5 @@
 # New version of containerd: 1.6.21 (using runc 1.1.7 & go 1.19.9)
-# New version of docker:  24.0.1 (using containerd 1.6.21) 
+# New version of docker:  24.0.2 (using containerd 1.6.21) 
 
 #Docker reference (tag)
 DOCKER_REF="v24.0.2" 


### PR DESCRIPTION
Rebuild Docker v24.0.2 due to failure to build Centos-8 packages.