### PR TITLE
Rebuild Docker v24.0.2 only for CentOS Stream 8

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -36,8 +36,8 @@ CONTAINERD_GO_VERSION="1.19.9"
 # If '1' disable Linux distribution discovery from get-env.sh
 # RPMS and DEBS must be set and contains the list of distro such as "fedora-34"
 ###
-DISABLE_DISTRO_DISCOVERY=0
-#RPMS="fedora-37"
+DISABLE_DISTRO_DISCOVERY=1
+RPMS="centos-8"
 #DEBS="ubuntu-jammy"
  
 ##


### PR DESCRIPTION
Rebuilding Docker v24.0.2 for CentOS Stream 8 to see if systemd-pam accepts a more recent version of systemd.