### PR TITLE
Rebuild Docker v24.0.2

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,4 +1,4 @@
-# New version of containerd: 1.6.21 (using runc 1.1.7 & go 1.19.9)
+# New version of containerd: 1.6.21 (using runc 1.1.7 and go 1.19.9)
 # New version of docker:  24.0.2 (using containerd 1.6.21) 
 
 #Docker reference (tag)


### PR DESCRIPTION
Rebuilding Docker v24.0.2 as local tests failed due to Docker Daemon not starting up on some distributions.