### PR TITLE
Retest staging Docker v24.0.3

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
 #  Update this file to spawn the prow job postsubmit-test-docker-staging
-# Version 24.0.3 / 1.6.21   
+# Version 24.0.3 / 1.6.21  


### PR DESCRIPTION
CentOS Stream 8 tests fail due to GLIBC error.