### PR TITLE
Build Docker v24.0.6

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,12 +1,12 @@
 # New version of containerd: 1.6.21 (using runc 1.1.7 and go 1.19.9)
-# New version of docker:  24.0.2 (using containerd 1.6.21) 
+# New version of docker:  24.0.6 (using containerd 1.6.21) 
 
 #Docker reference (tag)
-DOCKER_REF="v24.0.3" 
+DOCKER_REF="v24.0.6" 
 
 #Git ref for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:24.0
-DOCKER_PACKAGING_REF="974f151ee122ce6fd1b633c752cae6e41693e718"
+DOCKER_PACKAGING_REF="b4ce5ed9efe0da215741378df7ac9a1a2fd85b29"
 
 #If '1', build Docker (default)
 DOCKER_BUILD="1"


### PR DESCRIPTION
Build Docker v24.0.6 with the updated Docker image.