### PR TITLE
Use git hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ For now, this process is semi-automated, since we still need to manually edit th
 1. First prow job : [postsubmit-build-docker.yaml](https://github.com/ppc64le-cloud/test-infra/blob/master/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml#L2:L59)
 
 This postsubmit prow job is triggered by the editing of the [env.list](https://github.com/ppc64le-cloud/docker-ce-build/blob/main/env/env.list). This file contains the information we need to build the packages : 
-- DOCKER_VERS : latest version of docker, that we want to build
-- DOCKER_PACKAGING_REF : commit associated to the latest version of docker
+- DOCKER_TAG : latest version of docker, that we want to build
+- DOCKER_PACKAGING_HASH : commit associated to the latest version of docker-packaging
+- DOCKER_CLI_HASH : commit associated to the latest version of docker CLI
 - CONTAINERD_BUILD : if set to 1, it means that a new containerd version has been released that we have not built it yet ; if set to 0, it means that we have already built it in a previous prow job and that we do not need to build it again (we will still verify that no new distribution has been added).
-- CONTAINERD_VERS : latest version of containerd
-- CONTAINERD_PACKAGING_REF : commit associated to the latest version of containerd
+- CONTAINERD_TAG : latest version of containerd
+- CONTAINERD_PACKAGING_HASH : commit associated to the latest version of containerd
 - RUNC_VERS : runc version used to build the static packages
 
 This prow job builds the dynamic docker packages and then pushes them to our internal COS bucket, before creating the file 'env/date.list' which contains the current date (timestamp). We use the date in the directory where we store the docker packages in the COS bucket, so that we don't confuse the different builds.

--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -20,14 +20,14 @@ checkDirectory() {
   fi
 }
 
-DIR_COS_BUCKET="/mnt/s3_ppc64le-docker/prow-docker/build-docker-${DOCKER_REF}_${DATE}"
+DIR_COS_BUCKET="/mnt/s3_ppc64le-docker/prow-docker/build-docker-${DOCKER_TAG}_${DATE}"
 checkDirectory ${DIR_COS_BUCKET}
 
 if [[ ${CONTAINERD_BUILD} != "0" ]]
 then
-  DIR_CONTAINERD="/workspace/containerd-${CONTAINERD_REF}_${DATE}"
+  DIR_CONTAINERD="/workspace/containerd-${CONTAINERD_TAG}_${DATE}"
   checkDirectory ${DIR_CONTAINERD}
-  DIR_CONTAINERD_COS="${DIR_COS_BUCKET}/containerd-${CONTAINERD_REF}"
+  DIR_CONTAINERD_COS="${DIR_COS_BUCKET}/containerd-${CONTAINERD_TAG}"
   checkDirectory ${DIR_CONTAINERD_COS}
 fi
 
@@ -75,7 +75,7 @@ buildContainerd() {
     TARGET="quay.io/centos/centos:stream9"
   fi
 
-  local MAKE_OPTS="REF=${CONTAINERD_REF}"
+  local MAKE_OPTS="REF=${CONTAINERD_TAG}"
   if [[ ! -z "${CONTAINERD_GO_VERSION}" ]]
   then
     MAKE_OPTS+=" GOLANG_VERSION=${CONTAINERD_GO_VERSION}"
@@ -138,16 +138,16 @@ then
   cd containerd-packaging-ref
   git init
   git remote add origin https://github.com/docker/containerd-packaging.git
-  git fetch origin ${CONTAINERD_PACKAGING_REF}
+  git fetch origin ${CONTAINERD_PACKAGING_HASH}
   git checkout FETCH_HEAD
 
 
-  if [[ ! -z "${CONTAINERD_RUNC_REF}" ]]
+  if [[ ! -z "${CONTAINERD_RUNC_TAG}" ]]
   then
-    export RUNC_REF=${CONTAINERD_RUNC_REF}
+    export RUNC_REF=${CONTAINERD_RUNC_TAG}
   fi
 
-  make REF=${CONTAINERD_REF} checkout
+  make REF=${CONTAINERD_HASH} checkout
 fi
 
 before=$SECONDS
@@ -227,7 +227,7 @@ else
     # Check if the package is there for this distribution
     echo "= Check containerd ="
 
-    DIR_CONTAINERD="/workspace/containerd-${CONTAINERD_REF}_${DATE}"
+    DIR_CONTAINERD="/workspace/containerd-${CONTAINERD_TAG}_${DATE}"
 
     DISTRO_NAME="$(cut -d'-' -f1 <<<"${DISTRO}")"
     DISTRO_VERS="$(cut -d'-' -f2 <<<"${DISTRO}")"
@@ -259,9 +259,9 @@ then
     cd /workspace/containerd-packaging
     git init
     git remote add origin https://github.com/docker/containerd-packaging.git
-    git fetch origin ${CONTAINERD_PACKAGING_REF}
+    git fetch origin ${CONTAINERD_PACKAGING_HASH}
     git checkout FETCH_HEAD
-    make REF=${CONTAINERD_REF} checkout
+    make REF=${CONTAINERD_TAG} checkout
   fi
 
   while read -r line

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -28,13 +28,13 @@ checkDirectory() {
   fi
 }
 
-DIR_COS_BUCKET="/mnt/s3_ppc64le-docker/prow-docker/build-docker-${DOCKER_REF}_${DATE}"
+DIR_COS_BUCKET="/mnt/s3_ppc64le-docker/prow-docker/build-docker-${DOCKER_TAG}_${DATE}"
 checkDirectory ${DIR_COS_BUCKET}
 
-DIR_DOCKER="/workspace/docker-ce-${DOCKER_REF}_${DATE}"
+DIR_DOCKER="/workspace/docker-ce-${DOCKER_TAG}_${DATE}"
 checkDirectory ${DIR_DOCKER}
 
-DIR_DOCKER_COS="${DIR_COS_BUCKET}/docker-ce-${DOCKER_REF}"
+DIR_DOCKER_COS="${DIR_COS_BUCKET}/docker-ce-${DOCKER_TAG}"
 checkDirectory ${DIR_DOCKER_COS}
 
 DIR_LOGS="/workspace/logs"
@@ -83,7 +83,7 @@ buildDocker() {
   local PACKTYPE=$2
   local PACKTYPE_TMP=${PACKTYPE,,}
   local DIR=${PACKTYPE_TMP:0:3}
-  cd /workspace/docker-ce-packaging/${DIR} && VERSION=${DOCKER_REF} make ${DIR}build/bundles-ce-${DISTRO}-ppc64le.tar.gz &> ${DIR_LOGS}/build_docker_${DISTRO}.log
+  cd /workspace/docker-ce-packaging/${DIR} && VERSION=${DOCKER_TAG} make ${DIR}build/bundles-ce-${DISTRO}-ppc64le.tar.gz &> ${DIR_LOGS}/build_docker_${DISTRO}.log
 
   # Check if the dynamic docker package has been built
   if test -f ${DIR}build/bundles-ce-${DISTRO}-ppc64le.tar.gz

--- a/build-static.sh
+++ b/build-static.sh
@@ -40,14 +40,14 @@ echo "~~ Building static binaries ~~"
 pushd docker-ce-packaging/static
 
 echo "      make static-linux"
-echo "           DOCKER_REF    : ${DOCKER_REF}"
-echo "           CONTAINERD_REF: ${CONTAINERD_REF}"
+echo "           DOCKER_TAG    : ${DOCKER_TAG}"
+echo "           CONTAINERD_TAG: ${CONTAINERD_TAG}"
 echo "           RUNC_VERS     : ${RUNC_VERS}"
 DEBUG="-d"
 echo "           DEBUG         : ${DEBUG}"
 
 # Launch the build:
-VERSION=${DOCKER_REF} CONTAINERD_VERSION=${CONTAINERD_REF} RUNC_VERSION=${RUNC_VERS} make ${DEBUG} static-linux > ${DIR_LOGS}/${STATIC_LOG} 2>&1
+VERSION=${DOCKER_TAG} CONTAINERD_VERSION=${CONTAINERD_TAG} RUNC_VERSION=${RUNC_VERS} make ${DEBUG} static-linux > ${DIR_LOGS}/${STATIC_LOG} 2>&1
 RC=$?
 
 if [[ $RC -ne 0 ]]

--- a/env/env.list
+++ b/env/env.list
@@ -1,23 +1,31 @@
 # New version of containerd: 1.6.24 (using runc 1.1.9 and go 1.20.8)
 # New version of docker:  24.0.7 (using containerd 1.6.24) 
 
-#Docker reference (tag)
-DOCKER_REF="v24.0.7" 
+#Docker tag
+DOCKER_TAG="v24.0.7" 
 
-#Git ref for https://github.com/docker/docker-ce-packaging
+#Git hash for https://github.com/docker/docker-ce-packaging
 # We are currently on the branch:24.0
-DOCKER_PACKAGING_REF="c6a199e2417188d89b8916069b637e2bc7b1bdd5"
+DOCKER_PACKAGING_HASH="c6a199e2417188d89b8916069b637e2bc7b1bdd5"
+
+#Git hash for https://github.com/docker/cli
+# We are currently on the branch:24.0
+DOCKER_CLI_HASH="afdd53b4e341be38d2056a42113b938559bb1d94"
+
+#Git hash for github.com/moby/moby
+# We are currently on the branch:24.0
+DOCKER_ENGINE_HASH="311b9ff0aa93aa55880e1e5f8871c4fb69583426"
 
 #If '1', build Docker (default)
 DOCKER_BUILD="1"
 
-# Git ref for https://github.com/moby/moby/blob/master/hack/dind during tests
-DIND_COMMIT_DEBS=1f32e3c95d72a29b3eaacba156ed675dba976cb5
-DIND_COMMIT_RPMS=1f32e3c95d72a29b3eaacba156ed675dba976cb5
+# Git hash for https://github.com/moby/moby/blob/master/hack/dind during tests
+DIND_COMMIT_DEBS_HASH=1f32e3c95d72a29b3eaacba156ed675dba976cb5
+DIND_COMMIT_RPMS_HASH=1f32e3c95d72a29b3eaacba156ed675dba976cb5
 
-# Git ref for https://github.com/docker-library/docker/blob/master/24/dind/dockerd-entrypoint.sh during tests
-DOCKERD_COMMIT_DEBS=a3ca225e9c0e568cf87a7b60c951b939c3964c91
-DOCKERD_COMMIT_RPMS=a3ca225e9c0e568cf87a7b60c951b939c3964c91
+# Git hash for https://github.com/docker-library/docker/blob/master/24/dind/dockerd-entrypoint.sh during tests
+DOCKERD_COMMIT_DEBS_HASH=a3ca225e9c0e568cf87a7b60c951b939c3964c91
+DOCKERD_COMMIT_RPMS_HASH=a3ca225e9c0e568cf87a7b60c951b939c3964c91
 
 #If '1', build containerd (default) 
 #If '0', a previously build version of containerd will be used for the 'local' test
@@ -25,17 +33,20 @@ DOCKERD_COMMIT_RPMS=a3ca225e9c0e568cf87a7b60c951b939c3964c91
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
 CONTAINERD_BUILD="1"
 
-#Containerd reference (tag)
-CONTAINERD_REF="v1.6.24"
+#Containerd reference (hash)
+CONTAINERD_HASH="61f9fd88f79f081d64d6fa3bb1a0dc71ec870523"
 
-#Git ref for https://github.com/docker/containerd-packaging
-CONTAINERD_PACKAGING_REF="a39f74d295aeb6439b8a58b984c472fcd880763e"
+#Containerd reference (tag)
+CONTAINERD_TAG="v1.6.24"
+
+#Git hash for https://github.com/docker/containerd-packaging
+CONTAINERD_PACKAGING_HASH="a39f74d295aeb6439b8a58b984c472fcd880763e"
 
 #Runc Version, if "" default runc will be used for the static build
 RUNC_VERS="v1.1.9"
 
 #If not empty, specify the RUNC version for building containerd, ie "v1.1.4"
-CONTAINERD_RUNC_REF="v1.1.9"
+CONTAINERD_RUNC_TAG="v1.1.9"
 
 #If not empty, specify the GO version for building containerd ie "1.17.13"
 CONTAINERD_GO_VERSION="1.20.8"

--- a/get-env-containerd.sh
+++ b/get-env-containerd.sh
@@ -43,15 +43,15 @@ echo "Temporary fix: patching test suite to use centos 7"
 sed -i 's/Centos="latest"/Centos="centos7"/g' ${PATH_DOCKERTEST}/dockertest/version/version.go
 
 # Get the docker-ce packages
-mkdir /workspace/docker-ce-${DOCKER_REF}_${DATE}
-cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/build-docker-${DOCKER_REF}_${DATE}/docker-ce-${DOCKER_REF}/* /workspace/docker-ce-${DOCKER_REF}_${DATE}
+mkdir /workspace/docker-ce-${DOCKER_TAG}_${DATE}
+cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/build-docker-${DOCKER_TAG}_${DATE}/docker-ce-${DOCKER_TAG}/* /workspace/docker-ce-${DOCKER_TAG}_${DATE}
 
 # Get the containerd packages if CONTAINERD_BUILD=0
 if [[ ${CONTAINERD_BUILD} = "0" ]]
 then
     echo "CONTAINERD_BUILD is set to 0, we copy the containerd packages from the COS bucket"
-    mkdir /workspace/containerd-${CONTAINERD_REF}_${DATE}
-    cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/containerd-${CONTAINERD_REF}/* /workspace/containerd-${CONTAINERD_REF}_${DATE}
+    mkdir /workspace/containerd-${CONTAINERD_TAG}_${DATE}
+    cp -r ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}/prow-docker/containerd-${CONTAINERD_TAG}/* /workspace/containerd-${CONTAINERD_TAG}_${DATE}
 else
     echo "CONTAINERD_BUILD is set to 1"
 fi
@@ -64,7 +64,7 @@ then
 fi
 
 # Check if we have the docker packages
-if ! test -d /workspace/docker-ce-${DOCKER_REF}_${DATE}
+if ! test -d /workspace/docker-ce-${DOCKER_TAG}_${DATE}
 then
     echo "The docker packages have not been copied."
     exit 1
@@ -73,7 +73,7 @@ fi
 # Check if we have the containerd packages if CONTAINERD_BUILD is 0
 if [[ ${CONTAINERD_BUILD} = "0" ]]
 then
-    if test -d /workspace/containerd-${CONTAINERD_REF}
+    if test -d /workspace/containerd-${CONTAINERD_TAG}
     then
         echo "The containerd packages have been copied."
     else

--- a/get-env.sh
+++ b/get-env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Script to get the env.list file and to generate the list of distros
-# The env.list would contain the DOCKER_REF, the DOCKER_PACKAGING_REF, which is the commit associated to the version of docker,
+# The env.list would contain the DOCKER_TAG, the DOCKER_CLI hash, the DOCKER_ENGINE hash, the DOCKER_PACKAGING_HASH, which is the commit associated to the version of docker,
 # CONTAINERD_BUILD, which is set to 1 if there has been a new version of containerd released,
-# CONTAINERD_REF, CONTAINERD_PACKAGING_REF which is the commit associated to the version of containerd,
+# CONTAINERD_TAG, CONTAINERD_PACKAGING_HASH which is the commit associated to the version of containerd,
 # and RUNC_VERS, containing the version of runc used to build the static packages.
 
 set -eu
@@ -41,10 +41,10 @@ mkdir docker-ce-packaging
 pushd docker-ce-packaging
 git init
 git remote add origin https://github.com/docker/docker-ce-packaging.git
-git fetch origin ${DOCKER_PACKAGING_REF}
+git fetch origin ${DOCKER_PACKAGING_HASH}
 git checkout FETCH_HEAD
 
-make REF=${DOCKER_REF} checkout
+make REF=${DOCKER_TAG} DOCKER_ENGINE_HASH=${DOCKER_ENGINE_HASH} DOCKER_CLI_HASH=${DOCKER_CLI_HASH} checkout
 popd
 
 
@@ -70,12 +70,12 @@ then
     echo "The env.list has not been generated."
     exit 1
 else
-# Check there are 6 env variables in env.list from github
-    if grep -Fq "DOCKER_REF" ${FILE_ENV} && grep -Fq "DOCKER_PACKAGING_REF" ${FILE_ENV} && grep -Fq "CONTAINERD_BUILD" ${FILE_ENV} && grep -Fq "CONTAINERD_REF" ${FILE_ENV} && grep -Fq "CONTAINERD_PACKAGING_REF" ${FILE_ENV} && grep -Fq "RUNC_VERS" ${FILE_ENV}
+# Check there are 8 env variables in env.list from github
+    if grep -Fq "DOCKER_TAG" ${FILE_ENV} && grep -Fq "DOCKER_CLI_HASH" && grep -Fq "DOCKER_ENGINE_HASH" ${FILE_ENV} && grep -Fq "DOCKER_PACKAGING_HASH" ${FILE_ENV} && grep -Fq "CONTAINERD_BUILD" ${FILE_ENV} && grep -Fq "CONTAINERD_HASH" ${FILE_ENV} && grep -Fq "CONTAINERD_TAG" ${FILE_ENV} && grep -Fq "CONTAINERD_PACKAGING_HASH" ${FILE_ENV} && grep -Fq "RUNC_VERS" ${FILE_ENV}
     then
-        echo "DOCKER_REF : ${DOCKER_REF}, DOCKER_PACKAGING_REF : ${DOCKER_PACKAGING_REF}, CONTAINERD_BUILD : ${CONTAINERD_BUILD}, CONTAINERD_REF : ${CONTAINERD_REF}, CONTAINERD_PACKAGING_REF : ${CONTAINERD_PACKAGING_REF} and RUNC_VERS :${RUNC_VERS} are in env.list."
+        echo "DOCKER_TAG : ${DOCKER_TAG}, DOCKER_CLI_HASH : ${DOCKER_CLI_HASH}, DOCKER_ENGINE_HASH : ${DOCKER_ENGINE_HASH}, DOCKER_PACKAGING_HASH : ${DOCKER_PACKAGING_HASH}, CONTAINERD_BUILD : ${CONTAINERD_BUILD}, CONTAINERD_HASH : ${CONTAINERD_HASH}, CONTAINERD_TAG : ${CONTAINERD_TAG}, CONTAINERD_PACKAGING_HASH : ${CONTAINERD_PACKAGING_HASH} and RUNC_VERS :${RUNC_VERS} are in env.list."
     else
-        echo "DOCKER_REF, DOCKER_PACKAGING_REF, CONTAINERD_BUILD, CONTAINERD_REF, CONTAINERD_PACKAGING_REF and/or RUNC_VERS are not in env.list."
+        echo "DOCKER_TAG, DOCKER_CLI_HASH, DOCKER_ENGINE_HASH, DOCKER_PACKAGING_HASH, CONTAINERD_BUILD, CONTAINERD_HASH, CONTAINERD_TAG, CONTAINERD_PACKAGING_HASH and/or RUNC_VERS are not in env.list."
         cat /workspace/${FILE_ENV}
         exit 1
     fi

--- a/push-COS.sh
+++ b/push-COS.sh
@@ -18,23 +18,23 @@ mkdir -p ${PATH_COS}/s3_${COS_BUCKET_SHARED}
 s3fs ${COS_BUCKET_SHARED} ${PATH_COS}/s3_${COS_BUCKET_SHARED} -o url=${URL_COS_SHARED} -o passwd_file=${PATH_PASSWORD} -o ibm_iam_auth
 
 # Get the directory name ex: "docker-ce-20.10-11" (version without patch number then build tag)
-DIR_DOCKER_REF=$(eval "echo ${DOCKER_REF} | cut -d'v' -f2 | cut -d'.' -f1-2")
+DIR_DOCKER_TAG=$(eval "echo ${DOCKER_TAG} | cut -d'v' -f2 | cut -d'.' -f1-2")
 echo "List of the directories beginning with docker-ce : "
 ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/docker-ce-*/
 if [[ $? -eq 0 ]]
 then
-    DOCKER_LAST_BUILD_TAG=$(ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/docker-ce-${DIR_DOCKER_REF}-* | sort --version-sort | tail -1| cut -d'-' -f6)
+    DOCKER_LAST_BUILD_TAG=$(ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/docker-ce-${DIR_DOCKER_TAG}-* | sort --version-sort | tail -1| cut -d'-' -f6)
     DOCKER_BUILD_TAG=$((DOCKER_LAST_BUILD_TAG+1))
 else
     # If there are no directories yet
     DOCKER_BUILD_TAG="1"
 fi
-DIR_DOCKER_SHARED=docker-ce-${DIR_DOCKER_REF}-${DOCKER_BUILD_TAG}
+DIR_DOCKER_SHARED=docker-ce-${DIR_DOCKER_TAG}-${DOCKER_BUILD_TAG}
 echo "Build tag : ${DOCKER_BUILD_TAG}"
 
 echo "Copy the docker-ce packages to the COS bucket"
 mkdir ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_DOCKER_SHARED}
-cp -r /workspace/docker-ce-${DOCKER_REF}_${DATE}/* ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_DOCKER_SHARED}
+cp -r /workspace/docker-ce-${DOCKER_TAG}_${DATE}/* ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_DOCKER_SHARED}
 
 if test -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_DOCKER_SHARED}
 then
@@ -48,23 +48,23 @@ then
     # We built a new version of containerd
 
     # Get the directory name ex: "containerd-1.4-9" (version without patch number then build tag)
-    DIR_CONTAINERD_REF=$(eval "echo ${CONTAINERD_REF} | cut -d'v' -f2 | cut -d'.' -f1-2")
+    DIR_CONTAINERD_TAG=$(eval "echo ${CONTAINERD_TAG} | cut -d'v' -f2 | cut -d'.' -f1-2")
     echo "List of the directories beginning with containerd : "
     ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/containerd-*/
     if [[ $? -eq 0 ]]
     then
-        CONTAINERD_LAST_BUILD_TAG=$(ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/containerd-${DIR_CONTAINERD_REF}-* | sort --version-sort | tail -1| cut -d'-' -f5)
+        CONTAINERD_LAST_BUILD_TAG=$(ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/containerd-${DIR_CONTAINERD_TAG}-* | sort --version-sort | tail -1| cut -d'-' -f5)
         CONTAINERD_BUILD_TAG=$((CONTAINERD_LAST_BUILD_TAG+1))
     else
         # If there are no directories yet
         CONTAINERD_BUILD_TAG="1"
     fi
-    DIR_CONTAINERD=containerd-${DIR_CONTAINERD_REF}-${CONTAINERD_BUILD_TAG}
+    DIR_CONTAINERD=containerd-${DIR_CONTAINERD_TAG}-${CONTAINERD_BUILD_TAG}
     echo "Build tag : ${CONTAINERD_BUILD_TAG}"
 
     echo "Copy the containerd packages to the COS bucket"
     mkdir ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}
-    cp -r /workspace/containerd-${CONTAINERD_REF}_${DATE}/* ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}
+    cp -r /workspace/containerd-${CONTAINERD_TAG}_${DATE}/* ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}
 
     if test -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}
     then
@@ -80,19 +80,19 @@ else
         # distros-missing.txt exists
 
         # Get the directory name ex: "containerd-1.4-9" (version without patch number then build tag)
-        DIR_CONTAINERD_REF=$(eval "echo ${CONTAINERD_REF} | cut -d'v' -f2 | cut -d'.' -f1-2")
+        DIR_CONTAINERD_TAG=$(eval "echo ${CONTAINERD_TAG} | cut -d'v' -f2 | cut -d'.' -f1-2")
 
         echo "List of the directories beginning with containerd : "
         ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/containerd-*/
         if [[ $? -eq 0 ]]
         then
-            CONTAINERD_LAST_BUILD_TAG=$(ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/containerd-${DIR_CONTAINERD_REF}-* | sort --version-sort | tail -1| cut -d'-' -f5)
+            CONTAINERD_LAST_BUILD_TAG=$(ls -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/containerd-${DIR_CONTAINERD_TAG}-* | sort --version-sort | tail -1| cut -d'-' -f5)
             CONTAINERD_BUILD_TAG=$((CONTAINERD_LAST_BUILD_TAG+1))
         else
             # If there are no directories yet
             CONTAINERD_BUILD_TAG="1"
         fi
-        DIR_CONTAINERD=containerd-${DIR_CONTAINERD_REF}-${CONTAINERD_BUILD_TAG}
+        DIR_CONTAINERD=containerd-${DIR_CONTAINERD_TAG}-${CONTAINERD_BUILD_TAG}
         echo "Build tag : ${CONTAINERD_BUILD_TAG}"
 
         while read -r line
@@ -110,7 +110,7 @@ else
                 echo "Create ${DIR_CONTAINERD}/${DISTRO_NAME}"
                 # mkdir -p ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}/${DISTRO_NAME}
             fi
-            # cp -r /workspace/containerd-${CONTAINERD_REF}_${DATE}/${DISTRO_NAME}/${DISTRO_VERS} ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}/${DISTRO_NAME}
+            # cp -r /workspace/containerd-${CONTAINERD_TAG}_${DATE}/${DISTRO_NAME}/${DISTRO_VERS} ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}/${DISTRO_NAME}
             if test -d ${PATH_COS}/s3_${COS_BUCKET_SHARED}/${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}
             then
                 echo "${DIR_CONTAINERD} copied"
@@ -125,6 +125,6 @@ echo ""
 echo ""
 echo "---------------------------------------------------------"
 echo "COS bucket directory -> packages version :"
-echo "${DIR_CONTAINERD} -> containerd ${CONTAINERD_REF}"
-echo "${DIR_DOCKER_SHARED} -> docker ${DOCKER_REF}"
+echo "${DIR_CONTAINERD} -> containerd ${CONTAINERD_TAG}"
+echo "${DIR_DOCKER_SHARED} -> docker ${DOCKER_TAG}"
 echo "---------------------------------------------------------"

--- a/test.sh
+++ b/test.sh
@@ -55,10 +55,10 @@ testDynamicPackages() {
   local TEST_LOG="test_${DISTRO_NAME}_${DISTRO_VERS}.log"
   local TEST_JUNIT="junit-tests-${DISTRO_NAME}-${DISTRO_VERS}.xml"
   local BUILD_ARGS=""
-  local DIND_COMMIT_DEBS="${DIND_COMMIT_DEBS}"
-  local DIND_COMMIT_RPMS="${DIND_COMMIT_RPMS}"
-  local DOCKERD_COMMIT_DEBS="${DOCKERD_COMMIT_DEBS}"
-  local DOCKERD_COMMIT_RPMS="${DOCKERD_COMMIT_RPMS}"
+  local DIND_COMMIT_DEBS_HASH="${DIND_COMMIT_DEBS_HASH}"
+  local DIND_COMMIT_RPMS_HASH="${DIND_COMMIT_RPMS_HASH}"
+  local DOCKERD_COMMIT_DEBS_HASH="${DOCKERD_COMMIT_DEBS_HASH}"
+  local DOCKERD_COMMIT_RPMS_HASH="${DOCKERD_COMMIT_RPMS_HASH}"
   local TINI_VERSION="${TINI_VERSION}"
   export DISTRO_NAME
   export DISTRO_VERS
@@ -86,14 +86,14 @@ testDynamicPackages() {
     # Copy the docker-ce packages
     cp ${DIR_DOCKER}/bundles-ce-${DISTRO_NAME}-${DISTRO_VERS}-ppc64*.tar.gz .
     # Copy the containerd packages (we have two different configurations depending on the package type)
-    local CONTAINERD_REF_2=$(echo ${CONTAINERD_REF} | cut -d'v' -f2)
+    local CONTAINERD_TAG_2=$(echo ${CONTAINERD_TAG} | cut -d'v' -f2)
     if [[ ${PACKTYPE} == "DEBS" ]]
     then
       # For the debian packages, we don't want the dbgsym package
-      cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io_${CONTAINERD_REF_2}*_ppc64*.deb .
+      cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io_${CONTAINERD_TAG_2}*_ppc64*.deb .
     elif [[ ${PACKTYPE} == "RPMS" ]]
     then
-      cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io-${CONTAINERD_REF_2}*.ppc64*.rpm .
+      cp ${DIR_CONTAINERD}/${DISTRO_NAME}/${DISTRO_VERS}/ppc64*/containerd.io-${CONTAINERD_TAG_2}*.ppc64*.rpm .
     fi
 
     # Check if we have the docker-ce and containerd packages and the Dockerfile and the test-launch.sh
@@ -107,9 +107,9 @@ testDynamicPackages() {
 
 # Pass in the appropriate commits for DinD and dockerd-entrypoint.sh
   if [[ ${PACKTYPE} == "DEBS" ]];then 
-      BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_DEBS} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_DEBS}"
+      BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_DEBS_HASH} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_DEBS_HASH}"
   elif [[ ${PACKTYPE} == "RPMS" ]];then
-      BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_RPMS} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_RPMS} --build-arg TINI_VERSION=${TINI_VERSION}"
+      BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_RPMS_HASH} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_RPMS_HASH} --build-arg TINI_VERSION=${TINI_VERSION}"
   fi
 
   echo "### # Building the test image: ${IMAGE_NAME} # ###"
@@ -374,12 +374,12 @@ DIR_TEST="/workspace/tests"
 export DIR_TEST
 checkDirectory ${DIR_TEST}
 
-DIR_DOCKER="/workspace/docker-ce-${DOCKER_REF}_${DATE}"
-DIR_CONTAINERD="/workspace/containerd-${CONTAINERD_REF}_${DATE}"
+DIR_DOCKER="/workspace/docker-ce-${DOCKER_TAG}_${DATE}"
+DIR_CONTAINERD="/workspace/containerd-${CONTAINERD_TAG}_${DATE}"
 
 PATH_DOCKERFILE="${PATH_SCRIPTS}/test"
 
-DIR_COS_BUCKET="/mnt/s3_ppc64le-docker/prow-docker/build-docker-${DOCKER_REF}_${DATE}"
+DIR_COS_BUCKET="/mnt/s3_ppc64le-docker/prow-docker/build-docker-${DOCKER_TAG}_${DATE}"
 
 DIR_TEST_COS="${DIR_COS_BUCKET}/tests"
 checkDirectory ${DIR_TEST_COS}


### PR DESCRIPTION
1. We currently use the `DOCKER_REF` environment variable for mentioning the tag that will be used to checkout `Docker CLI` and `Docker Engine`. This pull request decouples these into two new environment variables; `DOCKER_CLI` and `DOCKER_ENGINE` which contain the git hashes for the [Docker CLI](https://github.com/docker/cli) and [Docker Engine](https://github.com/moby/moby/) repositories separately to reduce reliance on tags.
2. We currently have a single environment variable `CONTAINERD_REF` which contains the tag to the [CONTAINERD repository](https://github.com/containerd/containerd). This pull request replaces this with two variables, `CONTAINERD_TAG` (to create directories on the COS buckets for naming these built packages) and `CONTAINERD_HASH` for actually checking out the correct version of the `containerd` repository.