### PR TITLE
Set crun version to pinned version

### DIFF
--- a/test-containerd/test_on_powervs.sh
+++ b/test-containerd/test_on_powervs.sh
@@ -2,7 +2,6 @@
 
 set -ux
 
-CRUN_VERSION=1.14
 GO_VERSION=1.21.0
 
 RUNC_FLAVOR=$1
@@ -11,6 +10,8 @@ TEST_RUNTIME=$2
 cd /home/containerd_test
 cd containerd/
 git pull
+
+: "${CRUN_VERSION:=$(cat "$(pwd)/script/setup/crun-version")}"
 
 # Ensure Go is up to date
 curl -L -o /home/ubuntu/go${GO_VERSION}.linux-ppc64le.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-ppc64le.tar.gz


### PR DESCRIPTION
Set the crun version to the same version that is pinned by the containerd project.