### PR TITLE
Upstream CI unit and integration test updates

### DIFF
--- a/upstream-master-ci/build-dev-image.sh
+++ b/upstream-master-ci/build-dev-image.sh
@@ -1,4 +1,4 @@
 pushd ${PWD}/moby
-docker buildx build --load --force-rm -t "dockerbuildimage" .
+docker buildx build --load --force-rm -t "docker-dev" .
 popd
 exit 0

--- a/upstream-master-ci/integration-tests.sh
+++ b/upstream-master-ci/integration-tests.sh
@@ -1,29 +1,10 @@
-apt-get -y update && apt-get -y upgrade && apt-get -y install sudo iptables wget
-
-# Install Go
-wget https://golang.org/dl/go1.21.5.linux-ppc64le.tar.gz
-tar -C /usr/local -xzf go1.21.5.linux-ppc64le.tar.gz
-export PATH=/usr/local/go/bin:$PATH
-
-mkdir makebundles && cd makebundles
-git clone https://github.com/moby/moby.git
 pushd moby
-export GIT_COMMIT=$(git rev-list -n 1 HEAD)
-export GIT_URL="https://github.com/moby/moby.git"
-make binary dynbinary build run shell
-docker run --rm -t --privileged \
-                                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
-                                  --name dockerbuildimage \
-                                  -e DOCKER_EXPERIMENTAL \
-                                  -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
-                                  -e DOCKER_GRAPHDRIVER \
-                                  -e TESTDEBUG \
-                                  -e TEST_INTEGRATION_USE_SNAPSHOTTER \
-                                  -e TEST_SKIP_INTEGRATION_CLI \
-                                  -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
-                                  dockerbuildimage \
-                                  hack/make.sh \
-                                    dynbinary \
-                                    test-integration
-exit 0
+mkdir tmp
+touch tmp/out.txt
+make -o build test-integration 2>&1 | tee tmp/out.txt
+rc=$(grep "failure" tmp/out.txt | awk '{print $6;}')
+popd
+if [[ $rc == 0 ]]; then
+  exit 0
+fi
+exit 1

--- a/upstream-master-ci/prow-integration-tests.sh
+++ b/upstream-master-ci/prow-integration-tests.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-echo "Prow Job to run CI tests on the Docker packages"
+begin=$SECONDS
+
+echo "Prow Job to run integration tests on the Docker packages"
 
 ${PWD}/dockerctl.sh start
 
@@ -14,5 +16,20 @@ chmod ug+x ${PATH_CI}/get-env-ci.sh && ${PATH_CI}/get-env-ci.sh
 echo "*** Build dev image ***"
 chmod ug+x ${PATH_CI}/build-dev-image.sh && ${PATH_CI}/build-dev-image.sh
 
+exit_code_build=$?
+echo "Exit code build : ${exit_code_build}"
+
+if [[ $? != 0 ]]; then
+    echo "Building dev image failed."
+    exit 1
+fi
+
 echo "*** Run integration tests ***"
 chmod ug+x ${PATH_CI}/integration-tests.sh && ${PATH_CI}/integration-tests.sh
+
+exit_code_integration=$?
+echo "Exit code integration tests : ${exit_code_integration}"
+
+duration=$(( $SECONDS - $begin ))
+echo "DURATION INTEGRATION TEST $(( $duration / 60 )) minutes and $(( $duration % 60 )) seconds elapsed." 
+exit $exit_code_integration

--- a/upstream-master-ci/prow-unit-test-docker.sh
+++ b/upstream-master-ci/prow-unit-test-docker.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 set -u
 
+begin=$SECONDS
+
 # Path to the scripts
 PATH_CI="${PWD}/upstream-master-ci"
 export PATH_CI
 echo "Prow Job to run CI tests on the Docker packages"
+
+if [[ -z ${ARTIFACTS} ]]; then
+    ARTIFACTS=/logs/artifacts
+    echo "Setting ARTIFACTS to ${ARTIFACTS}"
+    mkdir -p ${ARTIFACTS}
+fi
 
 # Go to the workdir
 echo "* Starting dockerd and waiting for it *"
@@ -19,5 +27,21 @@ chmod ug+x ${PATH_CI}/get-env-ci.sh && ${PATH_CI}/get-env-ci.sh
 echo "*** Build dev image ***"
 chmod ug+x ${PATH_CI}/build-dev-image.sh && ${PATH_CI}/build-dev-image.sh
 
+exit_code_build=$?
+echo "Exit code build : ${exit_code_build}"
+
+if [[ $? != 0 ]]; then
+    echo "Building dev image failed."
+    exit 1
+fi
+
 echo "*** Run unit tests ***"
 chmod ug+x ${PATH_CI}/unit-tests.sh && ${PATH_CI}/unit-tests.sh
+
+exit_code_unit=$?
+echo "Exit code unit tests : ${exit_code_unit}"
+
+duration=$(( $SECONDS - $begin ))
+echo "DURATION UNIT TEST $(( $duration / 60 )) minutes and $(( $duration % 60 )) seconds elapsed." 
+
+exit $exit_code_unit

--- a/upstream-master-ci/unit-tests.sh
+++ b/upstream-master-ci/unit-tests.sh
@@ -1,23 +1,12 @@
-apt-get -y update && apt-get -y upgrade && apt-get -y install sudo iptables wget
-
-# Install Go
-wget https://golang.org/dl/go1.21.5.linux-ppc64le.tar.gz
-tar -C /usr/local -xzf go1.21.5.linux-ppc64le.tar.gz
-export PATH=/usr/local/go/bin:$PATH
-
-mkdir makebundles && cd makebundles
-git clone https://github.com/moby/moby.git
 pushd moby
-export GIT_COMMIT=$(git rev-list -n 1 HEAD)
-export GIT_URL="https://github.com/moby/moby.git"
-make binary dynbinary build run shell
-docker run --rm -t --privileged \
-                                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
-                                  --name dockerbuildimage \
-                                  -e DOCKER_EXPERIMENTAL \
-                                  -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
-                                  -e DOCKER_GRAPHDRIVER \
-                                  -e VALIDATE_REPO=${GIT_URL} \
-                                  dockerbuildimage \
-                                  hack/test/unit
-exit 0
+mkdir tmp
+touch tmp/out.txt
+make -o build test-unit 2>&1 | tee tmp/out.txt
+rc=$(grep "failure" tmp/out.txt | awk '{print $6;}')
+cp bundles/junit-report.xml ${ARTIFACTS}
+popd
+
+if [[ $rc == 0 ]]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
Reduce the amount of code and avoid doing a direct `docker run` against [moby](https://github.com/moby/moby/) repository and instead use their [Makefile](https://github.com/moby/moby/blob/master/Makefile) for the tests.