### PR TITLE
Skip cgroup version check to prevent integration CI test error

### DIFF
--- a/upstream-master-ci/integration-tests.sh
+++ b/upstream-master-ci/integration-tests.sh
@@ -1,7 +1,7 @@
 pushd moby
 mkdir tmp
 touch tmp/out.txt
-make -o build test-integration 2>&1 | tee tmp/out.txt
+TEST_IGNORE_CGROUP_CHECK=true make -o build test-integration 2>&1 | tee tmp/out.txt
 rc=$(grep "failure" tmp/out.txt | awk '{print $6;}')
 popd
 if [[ $rc == 0 ]]; then


### PR DESCRIPTION
If using `cgroup v2`, [integration-cli tests don't run](https://github.com/moby/moby/blob/master/Makefile#L64) [unless the cgroup check is skipped](https://github.com/moby/moby/commit/c2004fb8c4fdea8d48296f7ba92bcf981ba86978).
So skip it by [setting that variable](https://github.com/ppc64le-cloud/docker-ce-build/pull/198/files#diff-87ace9015eee2a9dfe41dd497701bd510b6671dd1228fa01f0f428a13588f443R6).