### PR TITLE
Store CI logs

### DIFF
--- a/upstream-master-ci/build-dev-image.sh
+++ b/upstream-master-ci/build-dev-image.sh
@@ -1,4 +1,27 @@
 pushd ${PWD}/moby
-docker buildx build --load --force-rm -t "docker-dev" .
+
+# Store logs by commit id to avoid overwriting
+export COMMIT=$(git rev-parse --short HEAD)
+
+checkDirectory() {
+  if ! test -d $1
+  then
+    mkdir $1
+    if [[ $? -ne 0 ]]; then
+      echo "Could not create $1, exiting."
+      exit 1
+    fi
+    echo "$1 created"
+  else
+    echo "$1 already exists, will not create again."
+  fi
+}
+
+DIR_LOGS_COS="/mnt/s3_ppc64le-docker/prow-docker/ppc64le-ci/${COMMIT}"
+checkDirectory ${DIR_LOGS_COS}
+
+rm -f ${DIR_LOGS_COS}/build-dev-image.log && touch ${DIR_LOGS_COS}/build-dev-image.log
+docker buildx build --load --force-rm -t "docker-dev" . 2>&1 | tee -a "${DIR_LOGS_COS}/build-dev-image.log"
+
 popd
 exit 0

--- a/upstream-master-ci/get-env-ci.sh
+++ b/upstream-master-ci/get-env-ci.sh
@@ -1,3 +1,23 @@
 set -o allexport
 # Clone the moby repository
 git clone https://github.com/moby/moby.git
+
+PATH_COS="/mnt"
+PATH_PASSWORD="/root/.s3fs_cos_secret"
+
+COS_BUCKET_PRIVATE="ppc64le-docker"
+URL_COS_PRIVATE="https://s3.us-south.cloud-object-storage.appdomain.cloud"
+
+
+# Mount the COS bucket if not mounted
+if ! test -d ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}
+then
+    # Set up the s3 secret if not already configured
+    if ! test -f ${PATH_PASSWORD}
+    then
+        echo ":${S3_SECRET_AUTH}" > ${PATH_PASSWORD}
+        chmod 600 ${PATH_PASSWORD}
+    fi
+    mkdir -p ${PATH_COS}/s3_${COS_BUCKET_PRIVATE}
+    s3fs ${COS_BUCKET_PRIVATE} ${PATH_COS}/s3_${COS_BUCKET_PRIVATE} -o url=${URL_COS_PRIVATE} -o passwd_file=${PATH_PASSWORD} -o ibm_iam_auth
+fi

--- a/upstream-master-ci/info.sh
+++ b/upstream-master-ci/info.sh
@@ -1,5 +1,28 @@
-docker version
-docker info
-curl -fsSL -o ${PWD}/check-config.sh "https://raw.githubusercontent.com/moby/moby/master/contrib/check-config.sh"
-bash ${PWD}/check-config.sh || true
+# Store logs by commit id to avoid overwriting
+pushd ${PWD}/moby
+export COMMIT=$(git rev-parse --short HEAD)
+popd
+
+checkDirectory() {
+  if ! test -d $1
+  then
+    echo "Could not create $1, exiting."
+    mkdir $1
+    if [[ $? -ne 0 ]]; then
+      exit 1
+    fi
+    echo "$1 created"
+  else
+    echo "$1 already created"
+  fi
+}
+
+DIR_LOGS_COS="/mnt/s3_ppc64le-docker/prow-docker/ppc64le-ci/${COMMIT}"
+checkDirectory ${DIR_LOGS_COS}
+
+rm -f ${DIR_LOGS_COS}/info.log && touch ${DIR_LOGS_COS}/info.log
+docker version 2>&1 | tee -a "${DIR_LOGS_COS}/info.log"
+docker info 2>&1 | tee -a "${DIR_LOGS_COS}/info.log"
+curl -fsSL -o ${PWD}/check-config.sh "https://raw.githubusercontent.com/moby/moby/master/contrib/check-config.sh" 2>&1 | tee -a "${DIR_LOGS_COS}/info.log"
+bash ${PWD}/check-config.sh 2>&1 | tee -a "${DIR_LOGS_COS}/info.log" || true
 exit 0

--- a/upstream-master-ci/integration-tests.sh
+++ b/upstream-master-ci/integration-tests.sh
@@ -1,8 +1,33 @@
 pushd moby
-mkdir tmp
-touch tmp/out.txt
-TEST_IGNORE_CGROUP_CHECK=true TESTDEBUG="true" make -o build test-integration 2>&1 | tee tmp/out.txt
-rc=$(grep "failure" tmp/out.txt | awk '{print $6;}')
+
+# Store logs by commit id to avoid overwriting
+export COMMIT=$(git rev-parse --short HEAD)
+
+checkDirectory() {
+  if ! test -d $1
+  then
+    echo "Could not create $1, exiting."
+    mkdir $1
+    if [[ $? -ne 0 ]]; then
+      exit 1
+    fi
+    echo "$1 created"
+  else
+    echo "$1 already created"
+  fi
+}
+
+DIR_LOGS_COS="/mnt/s3_ppc64le-docker/prow-docker/ppc64le-ci/${COMMIT}"
+checkDirectory ${DIR_LOGS_COS}
+
+TEST_IGNORE_CGROUP_CHECK=true
+TESTDEBUG="true"
+rm -f ${DIR_LOGS_COS}/integration.log && touch ${DIR_LOGS_COS}/integration.log
+echo "Integration test flags:"
+echo "TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TEST_DEBUG=${TEST_DEBUG}" > ${DIR_LOGS_COS}/integration.log
+TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TESTDEBUG=${TEST_DEBUG} make -o build test-integration 2>&1 | tee -a ${DIR_LOGS_COS}/integration.log
+
+rc=$(grep "failure" ${DIR_LOGS_COS}/integration.log | awk '{print $6;}')
 popd
 if [[ $rc == 0 ]]; then
   exit 0

--- a/upstream-master-ci/prow-info-docker.sh
+++ b/upstream-master-ci/prow-info-docker.sh
@@ -9,5 +9,9 @@ echo "Prow Job to run CI tests on the Docker packages"
 
 ${PWD}/dockerctl.sh start
 
+# Get the env files
+echo "** Set up (env files) **"
+chmod ug+x ${PATH_CI}/get-env-ci.sh && ${PATH_CI}/get-env-ci.sh
+
 echo "*** Check Config ***"
 chmod ug+x ${PATH_CI}/info.sh && ${PATH_CI}/info.sh

--- a/upstream-master-ci/unit-tests.sh
+++ b/upstream-master-ci/unit-tests.sh
@@ -1,8 +1,28 @@
 pushd moby
-mkdir tmp
-touch tmp/out.txt
-make -o build test-unit 2>&1 | tee tmp/out.txt
-rc=$(grep "failure" tmp/out.txt | awk '{print $6;}')
+
+# Store logs by commit id to avoid overwriting
+export COMMIT=$(git rev-parse --short HEAD)
+
+checkDirectory() {
+  if ! test -d $1
+  then
+    echo "Could not create $1, exiting."
+    mkdir $1
+    if [[ $? -ne 0 ]]; then
+      exit 1
+    fi
+    echo "$1 created"
+  else
+    echo "$1 already created"
+  fi
+}
+
+DIR_LOGS_COS="/mnt/s3_ppc64le-docker/prow-docker/ppc64le-ci/${COMMIT}"
+checkDirectory ${DIR_LOGS_COS}
+
+rm -f ${DIR_LOGS_COS}/unit.log && touch ${DIR_LOGS_COS}/unit.log
+make -o build test-unit 2>&1 | tee -a ${DIR_LOGS_COS}/unit.log
+rc=$(grep "failure" ${DIR_LOGS_COS}/unit.log | awk '{print $6;}')
 cp bundles/junit-report.xml ${ARTIFACTS}
 popd
 


### PR DESCRIPTION
We run _check config_, _build-dev-image_, _unit_ and _integration_ tests against [github.com/moby/moby](github.com/moby/moby). Store these logs to our COS bucket so they're not merely displayed on the terminal and can be reviewed later. The parent folder will be the shortened commit id of the latest commit against [github.com/moby/moby](github.com/moby/moby) and inside it, you will find `.log` files corresponding to the respective test suites (e.g. `202de33/integration.log`).