### PR TITLE
Set ndots to 0 in /etc/resolv.conf instead of dockerd flag

### DIFF
--- a/upstream-master-ci/prow-unit-test-docker.sh
+++ b/upstream-master-ci/prow-unit-test-docker.sh
@@ -13,8 +13,11 @@ if [[ -z ${ARTIFACTS} ]]; then
     echo "Setting ARTIFACTS to ${ARTIFACTS}"
     mkdir -p ${ARTIFACTS}
 fi
-# Start dockerd with ndots:0, otherwise TestDNSOptions fails.
-sed -i 's/dockerd \\/dockerd \\\n--dns-option ndots:0 \\/' /usr/local/bin/dockerd-entrypoint.sh
+
+# Set ndots to 0, otherwise TestDNSOptions fails.
+cp /etc/resolv.conf /etc/resolv1.conf
+sed -i 's/ndots:5.*/ndots:0/g' /etc/resolv1.conf 
+cp /etc/resolv1.conf /etc/resolv.conf
 
 # Go to the workdir
 echo "* Starting dockerd and waiting for it *"


### PR DESCRIPTION
We hoped https://github.com/ppc64le-cloud/docker-ce-build/pull/209/commits/176bbe167dec0c4a0ea966eef681173cb944e7ec will solve the unit test failure that checks ndots = 0 but it causes `dockerd` to not start whereas https://github.com/ppc64le-cloud/docker-ce-build/pull/209/commits/1bd3b015c364d6e69e2fbc053674c07fdeb6dd59 is not an elegant solution but makes the test pass at least.