### PR TITLE
0.9-ppc64le DinD image for build and tests

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -1,24 +1,24 @@
-# New version of containerd: 1.6.32 (using runc 1.1.12 and go 1.21.10)
-# New version of docker:  27.0.3 (using containerd 1.6.32)
+# New version of containerd: 1.7.19 (using runc 1.1.12 and go 1.21.12)
+# New version of docker:  27.1.0 (using containerd 1.7.19)
 
 #Docker tag
-DOCKER_TAG="v27.0.3" 
+DOCKER_TAG="v27.1.0" 
 
 #Git hash for https://github.com/docker/docker-ce-packaging
-# We are currently on the branch: 27.0
-DOCKER_PACKAGING_HASH="47a987492a6a2df97b8ea1d81b227d5787385fdd"
+# We are currently on the branch: 27.1
+DOCKER_PACKAGING_HASH="0b82433524224680d24d0cd099b16bbc5d8f4b75"
 
 #Git hash for https://github.com/docker/cli
-# We are currently on the branch:27.0
-DOCKER_CLI_HASH="7d4bcd863a4c863e650eed02a550dfeb98560b83"
+# We are currently on the branch:27.1
+DOCKER_CLI_HASH="63125853e3a21c84f3f59eac6a0943e2a4008cf6"
 
 #Git hash for github.com/moby/moby
-# We are currently on the branch:26.1
-DOCKER_ENGINE_HASH="662f78c0b1bb5114172427cfcb40491d73159be2"
+# We are currently on the branch:27.1
+DOCKER_ENGINE_HASH="a21b1a2d12e2c01542cb191eb526d7bfad0641e3"
 
 # quay.io image hash of the image quay.io/powercloud/docker-ce-build 
 # to be used for static builds
-DIND_IMG_STATIC_HASH="sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc"
+DIND_IMG_STATIC_HASH="sha256:f93b6d36ad414d30f584c6555d8c2116de58bd56601da36f4e13d4b5b624114a"
 
 #If '1', build Docker (default)
 DOCKER_BUILD="1"
@@ -27,21 +27,21 @@ DOCKER_BUILD="1"
 DIND_COMMIT_DEBS_HASH=65cfcc28ab37cb75e1560e4b4738719c07c6618e
 DIND_COMMIT_RPMS_HASH=65cfcc28ab37cb75e1560e4b4738719c07c6618e
 
-# Git hash for https://github.com/docker-library/docker/blob/master/24/dind/dockerd-entrypoint.sh during tests
-DOCKERD_COMMIT_DEBS_HASH=d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
-DOCKERD_COMMIT_RPMS_HASH=d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
+# Git hash for https://github.com/docker-library/docker/blob/master/27/dind/dockerd-entrypoint.sh during tests
+DOCKERD_COMMIT_DEBS_HASH=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
+DOCKERD_COMMIT_RPMS_HASH=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 
 #If '1', build containerd (default) 
 #If '0', a previously build version of containerd will be used for the 'local' test
 # The containerd packages are retrieved from the COS bucket such as:
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
-CONTAINERD_BUILD="0"
+CONTAINERD_BUILD="1"
 
 #Containerd reference (tag)
-CONTAINERD_TAG="v1.6.32"
+CONTAINERD_TAG="v1.7.19"
 
 #Git hash for https://github.com/docker/containerd-packaging
-CONTAINERD_PACKAGING_HASH="066b26edc6aa984eae6bcae7e68c4564e3f9e011"
+CONTAINERD_PACKAGING_HASH="0194852f4c91db1e60860043d860ff80470c9294"
 
 #Runc Version, if "" default runc will be used for the static build
 RUNC_VERS="v1.1.12"
@@ -50,7 +50,7 @@ RUNC_VERS="v1.1.12"
 CONTAINERD_RUNC_TAG="v1.1.12"
 
 #If not empty, specify the GO version for building containerd ie "1.17.13"
-CONTAINERD_GO_VERSION="1.21.10"
+CONTAINERD_GO_VERSION="1.21.12"
 
 ##
 # If '1' disable Linux distribution discovery from get-env.sh

--- a/images/docker-in-docker/Dockerfile
+++ b/images/docker-in-docker/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM debian:bookworm
 
-ENV CONTAINERD_VERSION=1.6.28-1
+ENV CONTAINERD_VERSION=1.6.32-1
 
-ENV DOCKER_VERSION=25.0.3-1
+ENV DOCKER_VERSION=27.0.3-1
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -75,11 +75,11 @@ RUN set -eux; \
 
 # https://github.com/docker/docker/tree/master/hack/dind
 ENV DIND_COMMIT 65cfcc28ab37cb75e1560e4b4738719c07c6618e
-ENV DOCKERD_COMMIT d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
+ENV DOCKERD_COMMIT b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 
 RUN set -eux; \
 curl https://raw.githubusercontent.com/moby/moby/${DIND_COMMIT}/hack/dind -o /usr/local/bin/dind; \
-curl https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/25/dind/dockerd-entrypoint.sh -o /usr/local/bin/dockerd-entrypoint.sh; \
+curl https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/27/dind/dockerd-entrypoint.sh -o /usr/local/bin/dockerd-entrypoint.sh; \
 chmod +x /usr/local/bin/dind; \
     chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
 cp $(which tini) "/usr/local/bin/docker-init";

--- a/test-DEBS/Dockerfile
+++ b/test-DEBS/Dockerfile
@@ -53,23 +53,23 @@ RUN set -eux; \
         echo 'dockremap:165536:65536' >> /etc/subuid; \
         echo 'dockremap:165536:65536' >> /etc/subgid
 
-# Commit pointing to the latest Docker-in-Docker script as of January 2024.
+# Commit pointing to the latest Docker-in-Docker script as of July 2024.
 # https://github.com/moby/moby/tree/master/hack/dind
 ARG DIND_COMMIT=65cfcc28ab37cb75e1560e4b4738719c07c6618e
-# Commit pointing to the latest stable Dockerd-entrypoint script as of January, 2024.
-# https://github.com/docker-library/docker/tree/master/25/dind
-ARG DOCKERD_COMMIT=d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
+# Commit pointing to the latest stable Dockerd-entrypoint script as of July, 2024.
+# https://github.com/docker-library/docker/tree/master/27/dind
+ARG DOCKERD_COMMIT=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 
 
 RUN set -eux; \
         curl "https://raw.githubusercontent.com/moby/moby/${DIND_COMMIT}/hack/dind" -o /usr/local/bin/dind; \
-        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/25/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
+        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/27/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
         chmod +x /usr/local/bin/dind; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
         cp $(which tini) "/usr/local/bin/docker-init"; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.21.9
+ARG GO_VERSION=1.22.5
 
 RUN set -eux; \
 	url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-RPMS/Dockerfile
+++ b/test-RPMS/Dockerfile
@@ -46,11 +46,11 @@ RUN set -eux; \
 ARG DIND_COMMIT=65cfcc28ab37cb75e1560e4b4738719c07c6618e
 # Commit pointing to the latest stable Dockerd-entrypoint script as of January, 2024.
 # https://github.com/docker-library/docker/tree/master/25/dind
-ARG DOCKERD_COMMIT=d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
+ARG DOCKERD_COMMIT=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 
 RUN set -eux; \
         curl "https://raw.githubusercontent.com/moby/moby/${DIND_COMMIT}/hack/dind" -o /usr/local/bin/dind; \
-        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/25/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
+        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/27/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
         chmod +x /usr/local/bin/dind; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
         git clone https://github.com/krallin/tini.git "/workspace/tini"; \
@@ -62,7 +62,7 @@ RUN set -eux; \
         popd; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.21.9
+ARG GO_VERSION=1.22.5
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-repo-DEBS/Dockerfile
+++ b/test-repo-DEBS/Dockerfile
@@ -60,17 +60,17 @@ COPY test-launch.sh /usr/local/bin/test-launch.sh
 ARG DIND_COMMIT=65cfcc28ab37cb75e1560e4b4738719c07c6618e
 # Commit pointing to the latest stable Dockerd-entrypoint script as of January, 2024.
 # https://github.com/docker-library/docker/tree/master/25/dind
-ARG DOCKERD_COMMIT=d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
+ARG DOCKERD_COMMIT=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 
 RUN set -eux; \
         curl "https://raw.githubusercontent.com/moby/moby/${DIND_COMMIT}/hack/dind" -o /usr/local/bin/dind; \
-        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/25/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
+        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/27/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
         chmod +x /usr/local/bin/dind; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
         cp $(which tini) "/usr/local/bin/docker-init"; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.21.9
+ARG GO_VERSION=1.22.5
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-repo-RPMS/Dockerfile
+++ b/test-repo-RPMS/Dockerfile
@@ -44,14 +44,14 @@ RUN set -eux; \
 ARG DIND_COMMIT=65cfcc28ab37cb75e1560e4b4738719c07c6618e
 # Commit pointing to the latest stable Dockerd-entrypoint script as of January, 2024.
 # https://github.com/docker-library/docker/tree/master/25/dind
-ARG DOCKERD_COMMIT=d3e33ac3bc1eab5d436b7ab2981ba539ebbb7275
+ARG DOCKERD_COMMIT=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 ARG TINI_VERSION=v0.19.0
 
 COPY test-launch.sh /usr/local/bin/test-launch.sh
 
 RUN set -eux; \
         curl "https://raw.githubusercontent.com/moby/moby/${DIND_COMMIT}/hack/dind" -o /usr/local/bin/dind; \
-        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/25/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
+        curl "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/27/dind/dockerd-entrypoint.sh" -o /usr/local/bin/dockerd-entrypoint.sh; \
         chmod +x /usr/local/bin/dind; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
         git clone https://github.com/krallin/tini.git "/workspace/tini"; \
@@ -63,7 +63,7 @@ RUN set -eux; \
         popd; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.21.9
+ARG GO_VERSION=1.22.5
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-static-alpine/Dockerfile
+++ b/test-static-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.14
+FROM golang:1.22.5-alpine3.20
 
 WORKDIR /workspace
 ENV WORKSPACE=/workspace \
@@ -54,15 +54,15 @@ RUN set -eux; \
 
 ENV MODPROBE_COMMIT 387e351394bfad74bceebf8303c6c8e39c3d4ed4
 # https://github.com/docker/docker/tree/master/hack/dind
-ENV DIND_COMMIT 42b1175eda071c0e9121e1d64345928384a93df1
+ENV DIND_COMMIT 65cfcc28ab37cb75e1560e4b4738719c07c6618e
 # ENV DIND_COMMIT ed89041433a031cafc0a0f19cfe573c31688d377
-ENV DOCKERD_COMMIT 8baa881aab85f8398d2edbbcc0da4bd1f556dd98
+ENV DOCKERD_COMMIT b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 # ENV DOCKERD_COMMIT 094faa88f437cafef7aeb0cc36e75b59046cc4b9
 
 RUN set -eux; \
 	wget -O /usr/local/bin/modprobe "https://raw.githubusercontent.com/docker-library/docker/${MODPROBE_COMMIT}/20.10/modprobe.sh"; \
         wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
-        wget -O /usr/local/bin/dockerd-entrypoint.sh "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/20.10/dind/dockerd-entrypoint.sh"; \
+        wget -O /usr/local/bin/dockerd-entrypoint.sh "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/27/dind/dockerd-entrypoint.sh"; \
 	chmod +x /usr/local/bin/dind; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
 	chmod +x /usr/local/bin/test-launch.sh;


### PR DESCRIPTION
A Docker image was built using https://github.com/ppc64le-cloud/docker-ce-build/compare/main...AshwinHIBM:docker-ce-build:0.9-ppc64le?expand=1#diff-c21b6a06ad8e557007d6d6b5d01fa16331d6d42b8cece38b90d15cf05b3c18d1 and tagged [0.9-ppc64le](https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:f93b6d36ad414d30f584c6555d8c2116de58bd56601da36f4e13d4b5b624114a). Update the Dockerfile here for keeping a record. Also propagate the same updates across the test Dockerfiles.
Also change `CONTAINERD_BUILD` to 1 so we can build Docker and containerd in one go.
Also build Docker v27.1.0 and containerd v1.7.19.