### PR TITLE
Test using containerd v1.7.19

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -35,7 +35,7 @@ DOCKERD_COMMIT_RPMS_HASH=b317cabfb873fef32ac8cad0cd58d6e6c32a63a4
 #If '0', a previously build version of containerd will be used for the 'local' test
 # The containerd packages are retrieved from the COS bucket such as:
 #  /mnt/s3_ppc64le-docker/prow-docker/containerd-v1.6.7
-CONTAINERD_BUILD="1"
+CONTAINERD_BUILD="0"
 
 #Containerd reference (tag)
 CONTAINERD_TAG="v1.7.19"


### PR DESCRIPTION
Copied containerd v1.7.19 packages to prow-docker/ in the COS bucket. Run tests using these.