### PR TITLE
Re-trigger Docker 27.1.0 and containerd 1.7.19 tests

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
-#  Update this file to spawn the staging prow-job
+#  Update this file to spawn the Docker staging prow-job
 # Version 27.1.0 / 1.7.19


### PR DESCRIPTION
Re-trigger Docker 27.1.0 and containerd 1.7.19 tests due to absence of containerd in the expected folder.