### PR TITLE
Block integration cli from main suite

### DIFF
--- a/upstream-master-ci/integration-tests.sh
+++ b/upstream-master-ci/integration-tests.sh
@@ -27,9 +27,12 @@ echo "Integration test flags:"
 echo "TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TEST_DEBUG=${TEST_DEBUG}" > ${DIR_LOGS_COS}/integration.log
 TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TEST_SKIP_INTEGRATION_CLI="true" TESTDEBUG=${TEST_DEBUG} make -o build test-integration 2>&1 | tee -a ${DIR_LOGS_COS}/integration.log
 
-rc=$(grep "failure" ${DIR_LOGS_COS}/integration.log | awk '{print $6;}')
-popd
-if [[ $rc == 0 ]]; then
-  exit 0
+# If there are any failures, the word "failure" necessarily appears towards
+# the end of the log
+tail -n 40 ${DIR_LOGS_COS}/integration.log | grep "failure" > /dev/null 2>&1
+if [[ $? != 0 ]]; then
+  popd  
+exit 0
 fi
+popd
 exit 1

--- a/upstream-master-ci/integration-tests.sh
+++ b/upstream-master-ci/integration-tests.sh
@@ -25,7 +25,7 @@ TESTDEBUG="true"
 rm -f ${DIR_LOGS_COS}/integration.log && touch ${DIR_LOGS_COS}/integration.log
 echo "Integration test flags:"
 echo "TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TEST_DEBUG=${TEST_DEBUG}" > ${DIR_LOGS_COS}/integration.log
-TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TESTDEBUG=${TEST_DEBUG} make -o build test-integration 2>&1 | tee -a ${DIR_LOGS_COS}/integration.log
+TEST_IGNORE_CGROUP_CHECK=${TEST_IGNORE_CGROUP_CHECK} TEST_SKIP_INTEGRATION_CLI="true" TESTDEBUG=${TEST_DEBUG} make -o build test-integration 2>&1 | tee -a ${DIR_LOGS_COS}/integration.log
 
 rc=$(grep "failure" ${DIR_LOGS_COS}/integration.log | awk '{print $6;}')
 popd


### PR DESCRIPTION
[Integration CLI tests present in the moby repository are deprecated](https://github.com/moby/moby/blob/master/TESTING.md#writing-new-integration-tests). Stop running them. This also includes a commit to return the correct exit code from integration tests.