### PR TITLE
Retest Docker v27.3.0 and containerd v1.7.22 staging

### DIFF
--- a/env/test-staging.list
+++ b/env/test-staging.list
@@ -1,3 +1,3 @@
 
-#  Update this file to spawn the Docker staging prow-job
+#  Update this file to spawn the Docker staging ProwJob
 # Version 27.3.0 / 1.7.22


### PR DESCRIPTION
Packages weren't available, they are now. Retest.