### PR TITLE
Obtain expected runc version programmatically while testing dynamic binaries

### DIFF
--- a/get-env-test.sh
+++ b/get-env-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Script to get containerd repository if RUNC_VERSION is unspecified
+
+set -o allexport
+source /workspace/${FILE_ENV}
+if [[ -z ${CONTAINERD_RUNC_TAG} ]]; then    
+    git clone --depth 1 --branch ${CONTAINERD_TAG} https://github.com/containerd/containerd.git
+fi

--- a/test-launch.sh
+++ b/test-launch.sh
@@ -34,7 +34,7 @@ if [[ ${DOCKER_SERVER_VERSION:1} != ${DOCKER_TAG:1} ]]; then
 
 fi
 if [[ ${CONTAINERD_VERSION} != ${CONTAINERD_TAG:1} ]]; then
-  echo "ERROR: Version mismatch: containerd version being tested is ${CONTAINERD_TAG:1} and containerd version downloaded from the Docker website is ${CONTAINERD}"
+  echo "ERROR: Version mismatch: containerd version being tested is ${CONTAINERD_TAG:1} and containerd version downloaded from the Docker website is ${CONTAINERD_VERSION}"
   exit 1
 fi
 

--- a/test-launch.sh
+++ b/test-launch.sh
@@ -18,24 +18,30 @@ DOCKER_CLI_VERSION=$(docker version --format '{{.Client.Version}}')
 DOCKER_SERVER_VERSION=$(docker version --format '{{.Server.Version}}')
 CONTAINERD_VERSION=$(docker version| awk '/containerd/{getline; print $2}')
 RUNC_VERSION=$(docker version| awk '/runc/{getline; print $2}')
-if [[ ${RUNC_VERSION} != ${CONTAINERD_RUNC_TAG:1} ]]; then
-  echo "ERROR: Version mismatch: RUNC version being tested is ${CONTAINERD_RUNC_TAG:1} and RUNC version downloaded from the Docker website is ${RUNC_VERSION}"
-  exit 1
-fi
+if [[ ${DISTRO_NAME} == "alpine" ]]; then
+  echo "Skip version checks for ${DISTRO_NAME}"
+else
+  CONTAINERD_RUNC_TAG=$(< /workspace/containerd/script/setup/runc-version)
 
-if [[ ${DOCKER_CLI_VERSION:1} != ${DOCKER_TAG:1} ]]; then
-  echo "ERROR: Version mismatch: Docker CLI version being tested is ${DOCKER_TAG:1} and Docker CLI version downloaded from the Docker website is ${DOCKER_CLI_VERSION:1}"
-  exit 1
-fi
+  if [[ ${RUNC_VERSION} != ${CONTAINERD_RUNC_TAG:1} ]]; then
+    echo "ERROR: Version mismatch: RUNC version being tested is ${CONTAINERD_RUNC_TAG:1} and RUNC version downloaded from the Docker website is ${RUNC_VERSION}"
+    exit 1
+  fi
 
-if [[ ${DOCKER_SERVER_VERSION:1} != ${DOCKER_TAG:1} ]]; then
-  echo "ERROR: Version mismatch: Docker Server version being tested is ${DOCKER_TAG:1} and Docker Server version downloaded from the Docker website is ${DOCKER_SERVER_VERSION:1}"
-  exit 1
+  if [[ ${DOCKER_CLI_VERSION:1} != ${DOCKER_TAG:1} ]]; then
+    echo "ERROR: Version mismatch: Docker CLI version being tested is ${DOCKER_TAG:1} and Docker CLI version downloaded from the Docker website is ${DOCKER_CLI_VERSION:1}"
+    exit 1
+  fi
 
-fi
-if [[ ${CONTAINERD_VERSION} != ${CONTAINERD_TAG:1} ]]; then
-  echo "ERROR: Version mismatch: containerd version being tested is ${CONTAINERD_TAG:1} and containerd version downloaded from the Docker website is ${CONTAINERD_VERSION}"
-  exit 1
+  if [[ ${DOCKER_SERVER_VERSION:1} != ${DOCKER_TAG:1} ]]; then
+    echo "ERROR: Version mismatch: Docker Server version being tested is ${DOCKER_TAG:1} and Docker Server version downloaded from the Docker website is ${DOCKER_SERVER_VERSION:1}"
+    exit 1
+
+  fi
+  if [[ ${CONTAINERD_VERSION} != ${CONTAINERD_TAG:1} ]]; then
+    echo "ERROR: Version mismatch: containerd version being tested is ${CONTAINERD_TAG:1} and containerd version downloaded from the Docker website is ${CONTAINERD_VERSION}"
+    exit 1
+  fi
 fi
 
 # Run the docker test suite that consists of 3 tests

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,11 @@ source env.list
 NCPUs=`grep processor /proc/cpuinfo | wc -l`
 echo "Nber of available CPUs: ${NCPUs}"
 
+
+# Get containerd repo if CONTAINERD_RUNC_TAG is unset
+echo "** Set up (env files) **"
+chmod ug+x ${PATH_SCRIPTS}/get-env-test.sh && ${PATH_SCRIPTS}/get-env-test.sh
+
 # Function to create the directory if it does not exist
 checkDirectory() {
   if ! test -d $1


### PR DESCRIPTION
Obtain the expected `runc` version if unspecified and compare it against the one installed as a part of pre-test validation for dynamic binaries. This PR also removes all the version checks for Docker CLI, Docker Engine and containerd versions for static binaries as static binaries follow a different naming convention for versions.