### PR TITLE
Use a single tag for building the CLI and Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ For now, this process is semi-automated, since we still need to manually edit th
 This postsubmit prow job is triggered by the editing of the [env.list](https://github.com/ppc64le-cloud/docker-ce-build/blob/main/env/env.list). This file contains the information we need to build the packages : 
 - DOCKER_TAG : latest version of docker, that we want to build
 - DOCKER_PACKAGING_HASH : commit associated to the latest version of docker-packaging
-- DOCKER_CLI_HASH : commit associated to the latest version of docker CLI
 - CONTAINERD_BUILD : if set to 1, it means that a new containerd version has been released that we have not built it yet ; if set to 0, it means that we have already built it in a previous prow job and that we do not need to build it again (we will still verify that no new distribution has been added).
 - CONTAINERD_TAG : latest version of containerd
 - CONTAINERD_PACKAGING_HASH : commit associated to the latest version of containerd

--- a/env/env.list
+++ b/env/env.list
@@ -8,14 +8,6 @@ DOCKER_TAG="v27.3.1"
 # We are currently on the branch: 27.3
 DOCKER_PACKAGING_HASH="2e114f340b0a846feb23295639b4d1d9cad5343e"
 
-#Git hash for https://github.com/docker/cli
-# We are currently on the branch:27.3
-DOCKER_CLI_HASH="ce1223035ac3ab8922717092e63a184cf67b493d"
-
-#Git hash for github.com/moby/moby
-# We are currently on the branch:27.3
-DOCKER_ENGINE_HASH="41ca978a0a5400cc24b274137efa9f25517fcc0b"
-
 # quay.io image hash of the image quay.io/powercloud/docker-ce-build 
 # to be used for static builds
 DIND_IMG_STATIC_HASH="sha256:b89afc315f96f5cfd43de82b3b02f9221983592b893f838d816db5954088c9fc"

--- a/get-env.sh
+++ b/get-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to get the env.list file and to generate the list of distros
-# The env.list would contain the DOCKER_TAG, the DOCKER_CLI hash, the DOCKER_ENGINE hash, the DOCKER_PACKAGING_HASH, which is the commit associated to the version of docker,
+# The env.list would contain the DOCKER_TAG, the DOCKER_PACKAGING_HASH, which is the commit associated to the version of docker,
 # CONTAINERD_BUILD, which is set to 1 if there has been a new version of containerd released,
 # CONTAINERD_TAG, CONTAINERD_PACKAGING_HASH which is the commit associated to the version of containerd,
 # and RUNC_VERS, containing the version of runc used to build the static packages.
@@ -57,7 +57,7 @@ git remote add origin https://github.com/docker/docker-ce-packaging.git
 git fetch origin ${DOCKER_PACKAGING_HASH}
 git checkout FETCH_HEAD
 
-make REF=${DOCKER_TAG} DOCKER_ENGINE_HASH=${DOCKER_ENGINE_HASH} DOCKER_CLI_HASH=${DOCKER_CLI_HASH} checkout
+make REF=${DOCKER_TAG} checkout
 popd
 
 
@@ -83,12 +83,12 @@ then
     echo "The env.list has not been generated."
     exit 1
 else
-# Check there are 9 env variables in env.list from github
-    if grep -Fq "DOCKER_TAG" ${FILE_ENV} && grep -Fq "DOCKER_CLI_HASH" && grep -Fq "DOCKER_ENGINE_HASH" ${FILE_ENV} && grep -Fq "DOCKER_PACKAGING_HASH" ${FILE_ENV} && grep -Fq "CONTAINERD_BUILD" ${FILE_ENV} && grep -Fq "CONTAINERD_TAG" ${FILE_ENV} && grep -Fq "CONTAINERD_PACKAGING_HASH" ${FILE_ENV} && grep -Fq "RUNC_VERS" ${FILE_ENV} && grep -Fq "DIND_IMG_STATIC_HASH" ${FILE_ENV}
+# Check there are 7 env variables in env.list from github
+    if grep -Fq "DOCKER_TAG" ${FILE_ENV} && grep -Fq "DOCKER_PACKAGING_HASH" ${FILE_ENV} && grep -Fq "CONTAINERD_BUILD" ${FILE_ENV} && grep -Fq "CONTAINERD_TAG" ${FILE_ENV} && grep -Fq "CONTAINERD_PACKAGING_HASH" ${FILE_ENV} && grep -Fq "RUNC_VERS" ${FILE_ENV} && grep -Fq "DIND_IMG_STATIC_HASH" ${FILE_ENV}
     then
-        echo "DOCKER_TAG : ${DOCKER_TAG}, DOCKER_CLI_HASH : ${DOCKER_CLI_HASH}, DOCKER_ENGINE_HASH : ${DOCKER_ENGINE_HASH}, DOCKER_PACKAGING_HASH : ${DOCKER_PACKAGING_HASH}, CONTAINERD_BUILD : ${CONTAINERD_BUILD}, CONTAINERD_TAG : ${CONTAINERD_TAG}, CONTAINERD_PACKAGING_HASH : ${CONTAINERD_PACKAGING_HASH}, RUNC_VERS :${RUNC_VERS} and ${DIND_IMG_STATIC_HASH} are in env.list."
+        echo "DOCKER_TAG : ${DOCKER_TAG}, DOCKER_PACKAGING_HASH : ${DOCKER_PACKAGING_HASH}, CONTAINERD_BUILD : ${CONTAINERD_BUILD}, CONTAINERD_TAG : ${CONTAINERD_TAG}, CONTAINERD_PACKAGING_HASH : ${CONTAINERD_PACKAGING_HASH}, RUNC_VERS :${RUNC_VERS} and ${DIND_IMG_STATIC_HASH} are in env.list."
     else
-        echo "DOCKER_TAG, DOCKER_CLI_HASH, DOCKER_ENGINE_HASH, DOCKER_PACKAGING_HASH, CONTAINERD_BUILD, CONTAINERD_TAG, CONTAINERD_PACKAGING_HASH, RUNC_VERS and/or DIND_IMG_STATIC_HASH are not in env.list."
+        echo "DOCKER_TAG, DOCKER_PACKAGING_HASH, CONTAINERD_BUILD, CONTAINERD_TAG, CONTAINERD_PACKAGING_HASH, RUNC_VERS and/or DIND_IMG_STATIC_HASH are not in env.list."
         cat /workspace/${FILE_ENV}
         exit 1
     fi


### PR DESCRIPTION
The Docker CLI and Engine repositories are tagged by their version, e.g. v27.4.1. Use tags to checkout these repositories rather than hashes. This saves our efforts by not requiring specifying the hashes for each of these repositories separately. This also eliminates the chance of human error caused by entering a wrong hash for either of the repositories.