### PR TITLE
Set FILE_ENV for sourcing CONTAINERD_TAG in tests

### DIFF
--- a/get-env-test.sh
+++ b/get-env-test.sh
@@ -2,6 +2,7 @@
 # Script to get containerd repository if RUNC_VERSION is unspecified
 
 set -o allexport
+FILE_ENV="env.list"
 source /workspace/${FILE_ENV}
 if [[ -z ${CONTAINERD_RUNC_TAG} ]]; then    
     git clone --depth 1 --branch ${CONTAINERD_TAG} https://github.com/containerd/containerd.git


### PR DESCRIPTION
https://github.com/ppc64le-cloud/docker-ce-build/pull/247 did not set FILE_ENV to env.list. Set it.