### PR TITLE
Exclude EOL Debian Bullseye from builds

### DIFF
--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -151,7 +151,7 @@ fi
 before=$SECONDS
 # 1) Build the list of distros
 # List of Distros that appear in the list though they are EOL or must not be built
-DisNo+=( "ubuntu-impish" "debian-buster" )
+DisNo+=( "ubuntu-impish" "debian-buster" "debian-bullseye" )
 for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -136,7 +136,7 @@ patchGoVersion /workspace/docker-ce-packaging/rpm
 before=$SECONDS
 # 1) Build the list of distros
 # List of Distros that appear in the list though they are EOL or must not be built
-DisNo+=( "ubuntu-impish" "debian-buster" )
+DisNo+=( "ubuntu-impish" "debian-buster" "debian-bullseye" )
 for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}

--- a/env/env.list
+++ b/env/env.list
@@ -60,7 +60,7 @@ TINI_VERSION=v0.19.0
 ##
 COS_BUCKET_SHARED="ibm-docker-builds"
 URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
-EXCLUSIONS+=( "ubuntu_impish" "debian_buster" "alpine" )
+EXCLUSIONS+=( "ubuntu_impish" "debian_buster" "alpine" "debian_bullseye" )
 ##
 #  If '1' disable push to shared COS
 # This is useful when testing or debugging the script

--- a/test.sh
+++ b/test.sh
@@ -450,7 +450,7 @@ echo "# Tests of the dynamic packages #"
 before=$SECONDS
 # 1) Build the list of distros
 # List of Distros that appear in the list though they are EOL or must not be built
-DisNo+=( "ubuntu-impish" "debian-buster" )
+DisNo+=( "ubuntu-impish" "debian-buster" "debian-bullseye" )
 for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}


### PR DESCRIPTION
Debian Bullseye for ppc64le has been removed from https://github.com/debuerreotype/docker-debian-artifacts/blob/32138bf51ca52d8a4a8dcf24953d464fbedbf4bb/bullseye/oci/index.json
but has not been removed from packaging: https://github.com/docker/docker-ce-packaging/tree/6d02ed464737ba98834002d7b6e87afff63112eb/deb
Trying to pull it results in a _manifest not found_ error causing the build process to end in a failure state. Add it to an exclusion list to exclude it from building.