### PR TITLE
Remove Debian-Buster and Ubuntu-Impish exclusion workarounds

### DIFF
--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -151,7 +151,7 @@ fi
 before=$SECONDS
 # 1) Build the list of distros
 # List of Distros that appear in the list though they are EOL or must not be built
-DisNo+=( "ubuntu-impish" "debian-buster" "debian-bullseye" )
+DisNo+=( "debian-bullseye" )
 for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -62,17 +62,6 @@ patchDockerFiles() {
   done
 }
 
-##
-# Patch GO image so that we use bullseye instead of buster which is EOL
-# For instance the golang:1.18.6-buster is only supported for x86
-##
-patchGoVersion() {
-  MKFILE_PATH=$1/Makefile
-
-  echo "Patching GO image from buster to bullseye for $MKFILE_PATH"
-  sed -ri  's/GO_VERSION\)\-buster/GO_VERSION\)\-bullseye/' $MKFILE_PATH
-}
-
 # Function to build docker packages
 # $1 : distro
 # $2 : DEBS or RPMS
@@ -130,13 +119,10 @@ cd /workspace/docker-ce-packaging/rpm
 patchDockerFiles .
 cd /workspace
 
-patchGoVersion /workspace/docker-ce-packaging/deb
-patchGoVersion /workspace/docker-ce-packaging/rpm
-
 before=$SECONDS
 # 1) Build the list of distros
 # List of Distros that appear in the list though they are EOL or must not be built
-DisNo+=( "ubuntu-impish" "debian-buster" "debian-bullseye" )
+DisNo+=( "debian-bullseye" )
 for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}

--- a/build-static.sh
+++ b/build-static.sh
@@ -20,22 +20,6 @@ then
   echo "RUNC_VERS = ${RUNC_VERS}"
 fi
 
-##
-# Patch GO image so that we use bullseye instead of buster which is EOL
-##
-patchGoVersion() {
-  MKFILE_PATH=$1/Makefile
-
-  echo "Patching GO image from buster to bullseye for $MKFILE_PATH"
-  sed -ri  's/GO_VERSION\)\-buster/GO_VERSION\)\-bullseye/' $MKFILE_PATH
-}
-
-patchGoVersion docker-ce-packaging/deb
-patchGoVersion docker-ce-packaging/rpm
-
-echo "Search for buster anywhere"
-grep -r buster *
-
 echo "~~ Building static binaries ~~"
 pushd docker-ce-packaging/static
 

--- a/env/env.list
+++ b/env/env.list
@@ -60,7 +60,7 @@ TINI_VERSION=v0.19.0
 ##
 COS_BUCKET_SHARED="ibm-docker-builds"
 URL_COS_SHARED="https://s3.us-east.cloud-object-storage.appdomain.cloud"
-EXCLUSIONS+=( "ubuntu_impish" "debian_buster" "alpine" "debian_bullseye" )
+EXCLUSIONS+=( "alpine" "debian_bullseye" )
 ##
 #  If '1' disable push to shared COS
 # This is useful when testing or debugging the script

--- a/test.sh
+++ b/test.sh
@@ -450,7 +450,7 @@ echo "# Tests of the dynamic packages #"
 before=$SECONDS
 # 1) Build the list of distros
 # List of Distros that appear in the list though they are EOL or must not be built
-DisNo+=( "ubuntu-impish" "debian-buster" "debian-bullseye" )
+DisNo+=( "debian-bullseye" )
 for PACKTYPE in DEBS RPMS
 do
   for DISTRO in ${!PACKTYPE}


### PR DESCRIPTION
None of the upstream files use Debian-Buster or Ubuntu-Impish anymore. Remove the workarounds that were in place earlier because these distributions were present in the upstream repository/repositories