### PR TITLE
CI bugfix: Add source file to get date to commit to prow-job-tracking branch

### DIFF
--- a/upstream-master-ci/prow-info-docker.sh
+++ b/upstream-master-ci/prow-info-docker.sh
@@ -25,7 +25,7 @@ ${PATH_CI}/info.sh
 
 if [[ $? == 0 ]]; then 
     chmod ug+x ./setup-pj-trigger.sh
-    ./setup-pj-trigger.sh -r ppc64le-cloud/docker-ce-build
+    ./setup-pj-trigger.sh -r ppc64le-cloud/docker-ce-build -s ${PATH_SCRIPTS}/env/date.list
 else
     if [[ $? == 1 ]]; then
         echo "Error checking the kernel configuration"


### PR DESCRIPTION
Since the current date is stored in PATH_SCRIPTS/env/date.list while running periodic-info-docker, we need to pass in this filepath to the script that triggers the next postsubmit CI jobs