### PR TITLE
Remove software-properties-common from Debian test Dockerfiles

### DIFF
--- a/test-DEBS/Dockerfile
+++ b/test-DEBS/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get -y update && apt-get -y upgrade && DEBIAN_FRONTEND="noninteractive" 
     dbus-user-session \
     git \
     gnupg2 \
-    software-properties-common \
     lsb-release\
     make\
     gcc\

--- a/test-repo-DEBS/Dockerfile
+++ b/test-repo-DEBS/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get -y update && apt-get -y upgrade && DEBIAN_FRONTEND="noninteractive" 
     dbus-user-session \
     git \
     gnupg2 \
-    software-properties-common \
     lsb-release\
     make\
     gcc\


### PR DESCRIPTION
software-properties-common is not required for us and not supported in Debian Trixie