### PR TITLE
1.1-ppc64le Docker-in-Docker image

### DIFF
--- a/env/env.list
+++ b/env/env.list
@@ -10,7 +10,7 @@ DOCKER_PACKAGING_HASH="c911c41d58c7156737d5a56d195f024a5fbfff4f"
 
 # quay.io image hash of the image quay.io/powercloud/docker-ce-build 
 # to be used for static builds
-DIND_IMG_STATIC_HASH="sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe"
+DIND_IMG_STATIC_HASH="sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30"
 
 #If '1', build Docker (default)
 DOCKER_BUILD="1"

--- a/images/docker-in-docker/Dockerfile
+++ b/images/docker-in-docker/Dockerfile
@@ -7,7 +7,7 @@ FROM public.ecr.aws/docker/library/debian:bookworm
 
 ENV CONTAINERD_VERSION=1.7.27-1
 
-ENV DOCKER_VERSION=28.1.0-1
+ENV DOCKER_VERSION=28.2.1-1
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -53,7 +53,7 @@ curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/amd64/d
 curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/containerd.io_${CONTAINERD_VERSION}_ppc64el.deb -o /workspace/tmp/containerd.io_${CONTAINERD_VERSION}_ppc64el.deb; \
 curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-ce-cli_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-ce-cli_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb; \
 curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-ce_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-ce_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb; \
-curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-buildx-plugin_0.12.1-1~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-buildx-plugin_0.10.5-1~debian.12~bookworm_ppc64el.deb; \
+curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-buildx-plugin_0.24.0-1~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-buildx-plugin_0.24.0-1~debian.12~bookworm_ppc64el.deb; \
 ;; \
     esac; \
     \
@@ -83,7 +83,8 @@ chmod +x /usr/local/bin/dind; \
     chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
 cp $(which tini) "/usr/local/bin/docker-init";
 
-RUN mkdir -p /etc/docker; touch /etc/docker/daemon.json; echo "{\"insecure-registries\" : [ \"registry:5000\" ]}" > /etc/docker/daemon.json;
+# Re-enable when enabling CI
+# RUN mkdir -p /etc/docker; touch /etc/docker/daemon.json; echo "{\"insecure-registries\" : [ \"registry:5000\" ]}" > /etc/docker/daemon.json;
 
 
 VOLUME /var/lib/docker

--- a/test-DEBS/Dockerfile
+++ b/test-DEBS/Dockerfile
@@ -52,10 +52,10 @@ RUN set -eux; \
         echo 'dockremap:165536:65536' >> /etc/subuid; \
         echo 'dockremap:165536:65536' >> /etc/subgid
 
-# Commit pointing to the latest Docker-in-Docker script as of May, 2025.
+# Commit pointing to the latest Docker-in-Docker script as of July, 2025.
 # https://github.com/moby/moby/tree/master/hack/dind
 ARG DIND_COMMIT=8d9e3502aba39127e4d12196dae16d306f76993d
-# Commit pointing to the latest stable Dockerd-entrypoint script as of May, 2025.
+# Commit pointing to the latest stable Dockerd-entrypoint script as of July, 2025.
 # https://github.com/docker-library/docker/tree/master/28/dind
 ARG DOCKERD_COMMIT=52c8bfa9869c9c5605c6c03dc9a82cfe426ace77
 
@@ -68,7 +68,7 @@ RUN set -eux; \
         cp $(which tini) "/usr/local/bin/docker-init"; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.5
 
 RUN set -eux; \
 	url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-RPMS/Dockerfile
+++ b/test-RPMS/Dockerfile
@@ -41,10 +41,10 @@ RUN set -eux; \
 	echo 'dockremap:165536:65536' >> /etc/subuid; \
 	echo 'dockremap:165536:65536' >> /etc/subgid
 
-# Commit pointing to the latest Docker-in-Docker script as of May, 2025.
+# Commit pointing to the latest Docker-in-Docker script as of July, 2025.
 # https://github.com/moby/moby/tree/master/hack/dind
 ARG DIND_COMMIT=8d9e3502aba39127e4d12196dae16d306f76993d
-# Commit pointing to the latest stable Dockerd-entrypoint script as of May, 2025.
+# Commit pointing to the latest stable Dockerd-entrypoint script as of July, 2025.
 # https://github.com/docker-library/docker/tree/master/28/dind
 ARG DOCKERD_COMMIT=52c8bfa9869c9c5605c6c03dc9a82cfe426ace77
 
@@ -62,7 +62,7 @@ RUN set -eux; \
         popd; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.5
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-launch.sh
+++ b/test-launch.sh
@@ -50,7 +50,7 @@ export GOPATH=${WORKSPACE}/test:/go
 export PATH="/workspace/test/bin:$PATH"
 export GO111MODULE=auto
 cd /workspace/test/src/github.ibm.com/powercloud/dockertest
-go install gotest.tools/gotestsum@v1.7.0
+go install gotest.tools/gotestsum@v1.12.3
 
 echo "* Go version:"
 go version

--- a/test-repo-DEBS/Dockerfile
+++ b/test-repo-DEBS/Dockerfile
@@ -54,10 +54,10 @@ RUN set -eux; \
 
 COPY test-launch.sh /usr/local/bin/test-launch.sh
 
-# Commit pointing to the latest Docker-in-Docker script as of May, 2025.
+# Commit pointing to the latest Docker-in-Docker script as of July, 2025.
 # https://github.com/moby/moby/tree/master/hack/dind
 ARG DIND_COMMIT=8d9e3502aba39127e4d12196dae16d306f76993d
-# Commit pointing to the latest stable Dockerd-entrypoint script as of May, 2025.
+# Commit pointing to the latest stable Dockerd-entrypoint script as of July, 2025.
 # https://github.com/docker-library/docker/tree/master/28/dind
 ARG DOCKERD_COMMIT=52c8bfa9869c9c5605c6c03dc9a82cfe426ace77
 
@@ -69,7 +69,7 @@ RUN set -eux; \
         cp $(which tini) "/usr/local/bin/docker-init"; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.5
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-repo-RPMS/Dockerfile
+++ b/test-repo-RPMS/Dockerfile
@@ -39,10 +39,10 @@ RUN set -eux; \
 	echo 'dockremap:165536:65536' >> /etc/subuid; \
 	echo 'dockremap:165536:65536' >> /etc/subgid
 
-# Commit pointing to the latest Docker-in-Docker script as of May, 2025.
+# Commit pointing to the latest Docker-in-Docker script as of July, 2025.
 # https://github.com/moby/moby/tree/master/hack/dind
 ARG DIND_COMMIT=8d9e3502aba39127e4d12196dae16d306f76993d
-# Commit pointing to the latest stable Dockerd-entrypoint script as of May, 2025.
+# Commit pointing to the latest stable Dockerd-entrypoint script as of July, 2025.
 # https://github.com/docker-library/docker/tree/master/28/dind
 ARG DOCKERD_COMMIT=52c8bfa9869c9c5605c6c03dc9a82cfe426ace77
 ARG TINI_VERSION=v0.19.0
@@ -63,7 +63,7 @@ RUN set -eux; \
         popd; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.5
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-static-alpine/Dockerfile
+++ b/test-static-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.24.3-alpine3.21
+FROM public.ecr.aws/docker/library/golang:1.24.5-alpine3.22
 
 WORKDIR /workspace
 ENV WORKSPACE=/workspace \

--- a/upstream-master-ci/integration-cli.sh
+++ b/upstream-master-ci/integration-cli.sh
@@ -11,8 +11,7 @@ sed -i 's/ADD --chmod=0755 https:\/\/github.com\/theupdateframework\/notary\/rel
 
 # The below replacements are needed because the 'Docker' image is
 # not supported on ppc64le hence we maintain our own.
-# TODO: Update this
-sed -i "s/docker:.*/quay.io\/powercloud\/docker-ce-build@sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe'/g" ./e2e/compose-env.yaml
+sed -i "s/docker:.*/quay.io\/powercloud\/docker-ce-build@sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30'/g" ./e2e/compose-env.yaml
 sed -i "/insecure-registry/d" ./e2e/compose-env.yaml
 TEST_DEBUG="true"
 echo "Integration CLI test flags:"


### PR DESCRIPTION
Update the scripts to use the updated 1.1-ppc64le Docker-in-Docker image. The scripts include updates to the Go version for the tests, Docker buildx plugin version update and update to the Docker version.
The jobs that will run the scripts can be found here: https://github.com/ppc64le-cloud/test-infra/pull/567
The updated image can be found here: https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30