### PR TITLE
Switch to new Docker Engine tagging

### DIFF
--- a/get-env.sh
+++ b/get-env.sh
@@ -72,7 +72,9 @@ git checkout FETCH_HEAD
 
 switchModelRepository
 
-make REF=${DOCKER_TAG} checkout
+DOCKER_CLI_REF=${DOCKER_TAG}
+DOCKER_ENGINE_REF="docker-${DOCKER_TAG}"
+make DOCKER_CLI_REF=${DOCKER_CLI_REF} DOCKER_ENGINE_REF=${DOCKER_ENGINE_REF} checkout
 popd
 
 


### PR DESCRIPTION
Docker Engine (https://github.com/moby/moby) now tags versions with docker-_version_. We need to check out the correct tag by prepending the version with the regex `docker-`