### PR TITLE
1.4-ppc64le Docker-in-Docker image

### DIFF
--- a/build-containerd.sh
+++ b/build-containerd.sh
@@ -54,14 +54,7 @@ buildContainerd() {
   mkdir /workspace/containerd-packaging-${DISTRO}
   cp -r /workspace/containerd-packaging-ref/* /workspace/containerd-packaging-${DISTRO}
   
-  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:8 ]]; then
-    ##
-    # Switch to quay.io for CentOS 8 stream
-    # See https://github.com/docker/containerd-packaging/pull/263
-    ##
-    echo "Switching to CentOS 8 stream and using quay.io"
-    TARGET="quay.io/centos/centos:stream8"
-  elif [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:9 ]]; then
+  if [[ "${DISTRO_NAME}:${DISTRO_VERS}" == centos:9 ]]; then
     ##
     # Switch to quay.io for CentOS 9 stream
     # See https://github.com/docker/containerd-packaging/pull/283

--- a/env/env.list
+++ b/env/env.list
@@ -10,7 +10,7 @@ DOCKER_PACKAGING_HASH="fb3937a19d0a4a1ce6dd9e130c2f2fcf1cd93e3c"
 
 # quay.io image hash of the image quay.io/powercloud/docker-ce-build 
 # to be used for static builds
-DIND_IMG_STATIC_HASH="sha256:06746a0fd11df7b559fcd780829323a1c05dff85fee7dc50c60df4e262e601ba"
+DIND_IMG_STATIC_HASH="sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12"
 
 #If '1', build Docker (default)
 DOCKER_BUILD="1"
@@ -51,9 +51,6 @@ CONTAINERD_GO_VERSION=""
 DISABLE_DISTRO_DISCOVERY=0
 #RPMS="centos-8"
 #DEBS="ubuntu-jammy"
-
-# The version of tini to be used in the RPM test Dockerfiles. 
-TINI_VERSION=v0.19.0
 
 ##
 # Shared COS Bucket info (with Docker)

--- a/images/docker-in-docker/Dockerfile
+++ b/images/docker-in-docker/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM public.ecr.aws/docker/library/debian:bookworm
 
-ENV CONTAINERD_VERSION=2.1.5-1
+ENV CONTAINERD_VERSION=2.2.3-1
 
-ENV DOCKER_VERSION=29.0.1-1
+ENV DOCKER_VERSION=29.3.1-1
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -54,7 +54,7 @@ curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/amd64/d
 curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/containerd.io_${CONTAINERD_VERSION}_ppc64el.deb -o /workspace/tmp/containerd.io_${CONTAINERD_VERSION}_ppc64el.deb; \
 curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-ce-cli_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-ce-cli_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb; \
 curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-ce_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-ce_${DOCKER_VERSION}~debian.12~bookworm_ppc64el.deb; \
-curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-buildx-plugin_0.30.1-1~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-buildx-plugin_0.30.1-1~debian.12~bookworm_ppc64el.deb; \
+curl https://download.docker.com/linux/debian/dists/bookworm/pool/stable/ppc64el/docker-buildx-plugin_0.33.0-1~debian.12~bookworm_ppc64el.deb -o /workspace/tmp/docker-buildx-plugin_0.33.0-1~debian.12~bookworm_ppc64el.deb; \
 ;; \
     esac; \
     \

--- a/test-DEBS/Dockerfile
+++ b/test-DEBS/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
         cp $(which tini) "/usr/local/bin/docker-init"; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.26.2
 
 RUN set -eux; \
 	url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-RPMS/Dockerfile
+++ b/test-RPMS/Dockerfile
@@ -10,7 +10,6 @@ ARG DISTRO_VERS
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
-ARG TINI_VERSION=v0.19.0
 ENV WORKSPACE=/workspace \
     TERM=xterm
 ENV PATH /usr/local/go/bin:$PATH
@@ -55,14 +54,13 @@ RUN set -eux; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
         git clone https://github.com/krallin/tini.git "/workspace/tini"; \
         pushd ./tini; \
-        git checkout -q "$TINI_VERSION"; \
         cmake .; \
         make tini-static; \
         cp tini-static "/usr/local/bin/docker-init"; \
         popd; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.26.2
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-repo-DEBS/Dockerfile
+++ b/test-repo-DEBS/Dockerfile
@@ -70,7 +70,7 @@ RUN set -eux; \
         cp $(which tini) "/usr/local/bin/docker-init"; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.26.2
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-repo-RPMS/Dockerfile
+++ b/test-repo-RPMS/Dockerfile
@@ -15,7 +15,6 @@ RUN mkdir -p /workspace
 ENV WORKSPACE=/workspace \
     TERM=xterm
 ENV PATH /usr/local/go/bin:$PATH
-ARG TINI_VERSION=v0.19.0
 RUN yum install -y dnf-plugins-core || :; \
     yum config-manager --set-enabled crb || :; \
     yum config-manager --set-enabled powertools || :; \
@@ -45,7 +44,6 @@ ARG DIND_COMMIT=8d9e3502aba39127e4d12196dae16d306f76993d
 # Commit pointing to the latest stable Dockerd-entrypoint script as of December, 2025.
 # https://github.com/docker-library/docker/tree/master/29/dind
 ARG DOCKERD_COMMIT=319e58aa0299128924649f0745054a1b8732545a
-ARG TINI_VERSION=v0.19.0
 
 COPY test-launch.sh /usr/local/bin/test-launch.sh
 
@@ -56,14 +54,13 @@ RUN set -eux; \
         chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
         git clone https://github.com/krallin/tini.git "/workspace/tini"; \
         pushd ./tini; \
-        git checkout -q "$TINI_VERSION"; \
         cmake .; \
         make tini-static; \
         cp tini-static "/usr/local/bin/docker-init"; \
         popd; \
         chmod +x /usr/local/bin/test-launch.sh;
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.26.2
 
 RUN set -eux; \
     url="https://dl.google.com/go/${GO_VERSION}";\

--- a/test-static-alpine/Dockerfile
+++ b/test-static-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.25.5-alpine3.22
+FROM public.ecr.aws/docker/library/golang:1.26.2-alpine3.23
 
 WORKDIR /workspace
 ENV WORKSPACE=/workspace \
@@ -52,7 +52,6 @@ RUN set -eux; \
 	echo 'dockremap:165536:65536' >> /etc/subuid; \
 	echo 'dockremap:165536:65536' >> /etc/subgid
 
-ENV MODPROBE_COMMIT 387e351394bfad74bceebf8303c6c8e39c3d4ed4
 # https://github.com/docker/docker/tree/master/hack/dind
 ENV DIND_COMMIT 8d9e3502aba39127e4d12196dae16d306f76993d
 # ENV DIND_COMMIT 8d9e3502aba39127e4d12196dae16d306f76993d
@@ -60,11 +59,11 @@ ENV DOCKERD_COMMIT 319e58aa0299128924649f0745054a1b8732545a
 # ENV DOCKERD_COMMIT 319e58aa0299128924649f0745054a1b8732545a
 
 RUN set -eux; \
-	wget -O /usr/local/bin/modprobe "https://raw.githubusercontent.com/docker-library/docker/${MODPROBE_COMMIT}/20.10/modprobe.sh"; \
-        wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
-        wget -O /usr/local/bin/dockerd-entrypoint.sh "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/29/dind/dockerd-entrypoint.sh"; \
+	wget -O /usr/local/bin/modprobe "https://raw.githubusercontent.com/docker-library/docker/refs/heads/master/modprobe.sh"; \
+    wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
+    wget -O /usr/local/bin/dockerd-entrypoint.sh "https://raw.githubusercontent.com/docker-library/docker/${DOCKERD_COMMIT}/29/dind/dockerd-entrypoint.sh"; \
 	chmod +x /usr/local/bin/dind; \
-        chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
+    chmod +x /usr/local/bin/dockerd-entrypoint.sh; \
 	chmod +x /usr/local/bin/test-launch.sh;
 
 # https://github.com/docker-library/docker/pull/166

--- a/test.sh
+++ b/test.sh
@@ -66,7 +66,6 @@ testDynamicPackages() {
   local DIND_COMMIT_RPMS_HASH="${DIND_COMMIT_RPMS_HASH}"
   local DOCKERD_COMMIT_DEBS_HASH="${DOCKERD_COMMIT_DEBS_HASH}"
   local DOCKERD_COMMIT_RPMS_HASH="${DOCKERD_COMMIT_RPMS_HASH}"
-  local TINI_VERSION="${TINI_VERSION}"
   export DISTRO_NAME
   export DISTRO_VERS
 
@@ -125,7 +124,7 @@ BUILD_ARGS+=" --build-arg GO_VERSION=${GO_VERSION}"
   if [[ ${PACKTYPE} == "DEBS" ]];then 
       BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_DEBS_HASH} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_DEBS_HASH}"
   elif [[ ${PACKTYPE} == "RPMS" ]];then
-      BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_RPMS_HASH} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_RPMS_HASH} --build-arg TINI_VERSION=${TINI_VERSION}"
+      BUILD_ARGS+=" --build-arg DIND_COMMIT=${DIND_COMMIT_RPMS_HASH} --build-arg DOCKERD_COMMIT=${DOCKERD_COMMIT_RPMS_HASH}"
   fi
 
   echo "### # Building the test image: ${IMAGE_NAME} # ###"


### PR DESCRIPTION
Update the scripts to use the updated 1.4-ppc64le Docker-in-Docker image. The scripts include updates to the Docker, containerd and Go versions.
Also remove the temporary fix to set the repository for CentOS 8 to Quay because [CentOS 8 is no longer supported](https://www.centos.org/cl-vs-cs/) so we no longer build it.

Tag/commit pinning of tini and modprobe has been stopped and we will now use the latest commit instead.
The jobs that will run the scripts can be found here: https://github.com/ppc64le-cloud/test-infra/pull/608.
The updated image can be found here: https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12